### PR TITLE
Custom Internal Calls

### DIFF
--- a/Examples/ExperimentalTesting.Native/ExperimentalTesting.Native.vcxproj
+++ b/Examples/ExperimentalTesting.Native/ExperimentalTesting.Native.vcxproj
@@ -140,6 +140,9 @@
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="SPL\InternalCall.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Examples/ExperimentalTesting.Native/ExperimentalTesting.Native.vcxproj
+++ b/Examples/ExperimentalTesting.Native/ExperimentalTesting.Native.vcxproj
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{e3ba4f2c-e79f-486e-8051-0835d8057c7d}</ProjectGuid>
+    <RootNamespace>ExperimentalTestingNative</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)Examples\ExperimentalTesting\bin\$(Configuration)\net8.0\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)Examples\ExperimentalTesting\bin\$(Configuration)\net8.0\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Examples/ExperimentalTesting.Native/ExperimentalTesting.Native.vcxproj.filters
+++ b/Examples/ExperimentalTesting.Native/ExperimentalTesting.Native.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Examples/ExperimentalTesting.Native/SPL/InternalCall.h
+++ b/Examples/ExperimentalTesting.Native/SPL/InternalCall.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifndef SPL_INTERNAL_CALL
+#define SPL_INTERNAL_CALL extern "C" __declspec(dllexport)
+#endif
+
+namespace SharpPluginLoader::Native {
+
+struct InternalCall {
+    const char* Name;
+    void* Function;
+};
+
+}

--- a/Examples/ExperimentalTesting.Native/dllmain.cpp
+++ b/Examples/ExperimentalTesting.Native/dllmain.cpp
@@ -2,10 +2,9 @@
 #include <cstdint>
 #include <Windows.h>
 
-struct InternalCall {
-    const char* Name;
-    void* Function;
-};
+#include "SPL/InternalCall.h"
+
+namespace SPLNative = SharpPluginLoader::Native;
 
 int64_t sum(int64_t a, int64_t b) {
     return a + b;
@@ -21,11 +20,11 @@ void log_message(int level, const wchar_t* message) {
     MessageBoxW(nullptr, message, buf, MB_OK);
 }
 
-extern "C" __declspec(dllexport) int get_internal_call_count() {
+SPL_INTERNAL_CALL int get_internal_call_count() {
     return 3;
 }
 
-extern "C" __declspec(dllexport) void collect_internal_calls(InternalCall * icalls) {
+SPL_INTERNAL_CALL void collect_internal_calls(SPLNative::InternalCall* icalls) {
     icalls[0] = { "Sum", (void*)sum };
     icalls[1] = { "ModifyValue", (void*)modify_value };
     icalls[2] = { "LogMessage", (void*)log_message };

--- a/Examples/ExperimentalTesting.Native/dllmain.cpp
+++ b/Examples/ExperimentalTesting.Native/dllmain.cpp
@@ -1,0 +1,37 @@
+#include <corecrt_wstdio.h>
+#include <cstdint>
+#include <Windows.h>
+
+struct InternalCall {
+    const char* Name;
+    void* Function;
+};
+
+int64_t sum(int64_t a, int64_t b) {
+    return a + b;
+}
+
+void modify_value(int* ptr) {
+    *ptr *= 2;
+}
+
+void log_message(int level, const wchar_t* message) {
+    wchar_t buf[1024];
+    (void)swprintf_s(buf, L"LogLevel: %d", level);
+    MessageBoxW(nullptr, message, buf, MB_OK);
+}
+
+extern "C" __declspec(dllexport) int get_internal_call_count() {
+    return 3;
+}
+
+extern "C" __declspec(dllexport) void collect_internal_calls(InternalCall * icalls) {
+    icalls[0] = { "Sum", (void*)sum };
+    icalls[1] = { "ModifyValue", (void*)modify_value };
+    icalls[2] = { "LogMessage", (void*)log_message };
+}
+
+BOOL WINAPI DllMain(HINSTANCE, DWORD, LPVOID) {
+    return TRUE;
+}
+

--- a/Examples/ExperimentalTesting/ExperimentalTesting.csproj
+++ b/Examples/ExperimentalTesting/ExperimentalTesting.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +13,9 @@
       <Private>False</Private>
       <CopyLocalSatelliteAssemblies>False</CopyLocalSatelliteAssemblies>
     </ProjectReference>
+    <ProjectReference Include="..\..\SharpPluginLoader.InternalCallGenerator\SharpPluginLoader.InternalCallGenerator.csproj" 
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
   </ItemGroup>
 
 </Project>

--- a/Examples/ExperimentalTesting/InternalCalls.cs
+++ b/Examples/ExperimentalTesting/InternalCalls.cs
@@ -4,8 +4,14 @@ using SharpPluginLoader.Core;
 
 namespace ExperimentalTesting;
 
+public struct HasRefTypes
+{
+    public string str;
+    public MtVector2 vec;
+}
+
 [InternalCallManager]
-public unsafe partial class InternalCalls
+public partial class InternalCalls
 {
     // Test with simple primitive types
     [InternalCall]
@@ -13,15 +19,15 @@ public unsafe partial class InternalCalls
 
     // Test with single pointer type
     [InternalCall]
-    public static partial void TestPointers(double* values);
+    public static unsafe partial void TestPointers(double* values);
 
     // Test with mixed unmanaged types
     [InternalCall]
-    public static partial char ProcessData(byte* data, int length, ref ushort dataId);
+    public static unsafe partial char ProcessData(byte* data, int length, ref ushort dataId);
 
     // Test with array and pointer types
     [InternalCall]
-    public static partial void TransformCoordinates(float[] coords, MtVector3* transformMatrix);
+    public static unsafe partial void TransformCoordinates(float[] coords, MtVector3* transformMatrix);
 
     // Test with InternalCallOptions and ref parameter
     [InternalCall(InternalCallOptions.Unsafe)]
@@ -29,7 +35,7 @@ public unsafe partial class InternalCalls
 
     // Test with no return value and primitive parameters
     [InternalCall]
-    public static partial void LogMessage(int level, char* message);
+    public static unsafe partial void LogMessage(int level, char* message);
 
     // Test with complex struct return type and primitive parameters
     [InternalCall]
@@ -37,7 +43,7 @@ public unsafe partial class InternalCalls
 
     // Test with pointer to struct and primitive types
     [InternalCall]
-    public static partial MtVector2* CreateVector(int x, int y);
+    public static unsafe partial MtVector2* CreateVector(int x, int y);
 
     // Test with multiple ref and out parameters
     [InternalCall]
@@ -45,5 +51,34 @@ public unsafe partial class InternalCalls
 
     // Test with mixed array, pointer, and primitive types
     [InternalCall]
-    public static partial void ProcessBuffers(byte[] inputBuffer, float* outputBuffer, int bufferSize);
+    public static unsafe partial void ProcessBuffers(byte[] inputBuffer, float* outputBuffer, int bufferSize);
+
+    // Test with strings
+    [InternalCall]
+    public static partial MtVector2 Parse(string str);
+
+    [InternalCall]
+    [return: WideString]
+    public static partial string Format(MtVector2 vec, [WideString] string str);
+
+    [InternalCall]
+    public static partial void EnumTest(PropType type);
+
+    [InternalCall]
+    public static partial void StructTest(HasRefTypes type);
+
+    [InternalCall]
+    public static partial void SpanTest(Span<byte> span);
+
+    [InternalCall]
+    public static partial void ReadOnlySpanTest(ReadOnlySpan<byte> span);
+
+    [InternalCall]
+    public static partial void MemoryTest(Memory<byte> memory);
+    
+    [InternalCall]
+    public static partial void ReadOnlyMemoryTest(ReadOnlyMemory<byte> memory);
+
+    [InternalCall]
+    public static partial void ListTest(List<byte> list);
 }

--- a/Examples/ExperimentalTesting/InternalCalls.cs
+++ b/Examples/ExperimentalTesting/InternalCalls.cs
@@ -14,7 +14,7 @@ public struct HasRefTypes
 public partial class InternalCalls
 {
     // Test with simple primitive types
-    [InternalCall]
+    [InternalCall(InternalCallOptions.Unsafe)]
     public static partial long Sum(long a, long b);
 
     // Test with single pointer type
@@ -35,7 +35,7 @@ public partial class InternalCalls
 
     // Test with no return value and primitive parameters
     [InternalCall]
-    public static unsafe partial void LogMessage(int level, char* message);
+    public static unsafe partial void LogMessage(int level, [WideString] string message);
 
     // Test with complex struct return type and primitive parameters
     [InternalCall]

--- a/Examples/ExperimentalTesting/InternalCalls.cs
+++ b/Examples/ExperimentalTesting/InternalCalls.cs
@@ -1,0 +1,49 @@
+﻿using SharpPluginLoader.InternalCallGenerator;
+using SharpPluginLoader.Core.MtTypes;
+using SharpPluginLoader.Core;
+
+namespace ExperimentalTesting;
+
+[InternalCallManager]
+public unsafe partial class InternalCalls
+{
+    // Test with simple primitive types
+    [InternalCall]
+    public static partial long Sum(long a, long b);
+
+    // Test with single pointer type
+    [InternalCall]
+    public static partial void TestPointers(double* values);
+
+    // Test with mixed unmanaged types
+    [InternalCall]
+    public static partial char ProcessData(byte* data, int length, ref ushort dataId);
+
+    // Test with array and pointer types
+    [InternalCall]
+    public static partial void TransformCoordinates(float[] coords, MtVector3* transformMatrix);
+
+    // Test with InternalCallOptions and ref parameter
+    [InternalCall(InternalCallOptions.Unsafe)]
+    public static partial void ModifyValue(ref int value);
+
+    // Test with no return value and primitive parameters
+    [InternalCall]
+    public static partial void LogMessage(int level, char* message);
+
+    // Test with complex struct return type and primitive parameters
+    [InternalCall]
+    public static partial MtMatrix4X4 ComputeStruct(int param1, float param2);
+
+    // Test with pointer to struct and primitive types
+    [InternalCall]
+    public static partial MtVector2* CreateVector(int x, int y);
+
+    // Test with multiple ref and out parameters
+    [InternalCall]
+    public static partial void TestRefOutParameters(ref float a, out double b, ref MtVector2 vec);
+
+    // Test with mixed array, pointer, and primitive types
+    [InternalCall]
+    public static partial void ProcessBuffers(byte[] inputBuffer, float* outputBuffer, int bufferSize);
+}

--- a/Examples/ExperimentalTesting/Plugin.cs
+++ b/Examples/ExperimentalTesting/Plugin.cs
@@ -3,9 +3,11 @@ using System.Collections.Specialized;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using ImGuiNET;
 using SharpPluginLoader.Core;
 using SharpPluginLoader.Core.Entities;
 using SharpPluginLoader.Core.Experimental;
+using SharpPluginLoader.Core.Rendering;
 using SharpPluginLoader.Core.Resources;
 
 namespace ExperimentalTesting
@@ -18,11 +20,10 @@ namespace ExperimentalTesting
         public delegate void ReleaseResourceDelegate(MtObject resourceMgr, Resource resource);
         private MarshallingHook<CreateShinyDropDelegate> _createShinyDropHook = null!;
         private MarshallingHook<ReleaseResourceDelegate> _releaseResourceHook = null!;
-        private int _intRef = 0;
-        public ref int GetIntRef()
-        {
-            return ref _intRef;
-        }
+        private int _value = 5;
+        private string _str = "Hello World!";
+        private long _a, _b, _sum;
+
         public unsafe void CreateShinyDropHook(MtObject a, int b, int c, nint d, long e, uint f)
         {
             Log.Info($"CreateShinyDropHook: {a},{b},{c},{d},{e},{f}");
@@ -38,13 +39,39 @@ namespace ExperimentalTesting
 
         public PluginData Initialize()
         {
-            return new PluginData();
+            return new PluginData
+            {
+                OnImGuiRender = true
+            };
         }
 
         public void OnLoad()
         {
             //_createShinyDropHook = MarshallingHook.Create<CreateShinyDropDelegate>(CreateShinyDropHook, 0x1402cb1d0);
             //_releaseResourceHook = MarshallingHook.Create<ReleaseResourceDelegate>(ReleaseResourceHook, 0x142224890);
+        }
+
+        public void OnImGuiRender()
+        {
+            ImGui.InputText("Message", ref _str, 512);
+            ImGui.SameLine();
+            if (ImGui.Button("Log"))
+                InternalCalls.LogMessage(1, _str);
+
+            ImGui.Separator();
+
+            ImGuiExtensions.InputScalar("A", ref _a);
+            ImGui.SameLine();
+            ImGuiExtensions.InputScalar("B", ref _b);
+            ImGui.SameLine();
+            ImGui.Text($"Sum: {InternalCalls.Sum(_a, _b)}");
+
+            ImGui.Separator();
+
+            ImGui.InputInt("Value", ref _value);
+            ImGui.SameLine();
+            if (ImGui.Button("Modify"))
+                InternalCalls.ModifyValue(ref _value);
         }
     }
 }

--- a/Examples/ExperimentalTesting/Plugin.cs
+++ b/Examples/ExperimentalTesting/Plugin.cs
@@ -1,4 +1,9 @@
-﻿using SharpPluginLoader.Core;
+﻿using System.Collections;
+using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using SharpPluginLoader.Core;
 using SharpPluginLoader.Core.Entities;
 using SharpPluginLoader.Core.Experimental;
 using SharpPluginLoader.Core.Resources;
@@ -13,14 +18,18 @@ namespace ExperimentalTesting
         public delegate void ReleaseResourceDelegate(MtObject resourceMgr, Resource resource);
         private MarshallingHook<CreateShinyDropDelegate> _createShinyDropHook = null!;
         private MarshallingHook<ReleaseResourceDelegate> _releaseResourceHook = null!;
-
-        public void CreateShinyDropHook(MtObject a, int b, int c, nint d, long e, uint f)
+        private int _intRef = 0;
+        public ref int GetIntRef()
+        {
+            return ref _intRef;
+        }
+        public unsafe void CreateShinyDropHook(MtObject a, int b, int c, nint d, long e, uint f)
         {
             Log.Info($"CreateShinyDropHook: {a},{b},{c},{d},{e},{f}");
             _createShinyDropHook.Original(a, b, c, d, e, f);
         }
 
-        public void ReleaseResourceHook(MtObject resourceMgr, Resource resource)
+        public unsafe void ReleaseResourceHook(MtObject resourceMgr, Resource resource)
         {
             Log.Info($"Releasing Resource: {resource.FilePath}.{resource.FileExtension}" + 
                      (resource.Get<int>(0x5C) == 1 ? " | Unloading..." : ""));

--- a/SharpPluginLoader.Core/InternalCallManager.cs
+++ b/SharpPluginLoader.Core/InternalCallManager.cs
@@ -11,6 +11,15 @@ namespace SharpPluginLoader.Core
         public string Name => Marshal.PtrToStringAnsi(_fieldName) ?? string.Empty;
     }
 
+    /// <summary>
+    /// This attribute is used to mark a class as an internal call manager.
+    /// There can only be one internal call manager per plugin.
+    ///
+    /// The internal call manager is where the plugin keeps all of its internal calls.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class InternalCallManagerAttribute : Attribute;
+
     internal static class InternalCallManager
     {
         public static unsafe void UploadInternalCalls(InternalCall* internalCalls, uint internalCallsCount)

--- a/SharpPluginLoader.Core/Memory/MemoryUtil.cs
+++ b/SharpPluginLoader.Core/Memory/MemoryUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace SharpPluginLoader.Core.Memory
 {
@@ -250,6 +251,64 @@ namespace SharpPluginLoader.Core.Memory
         {
             NativeMemory.Free(address);
         }
+
+        #endregion
+
+        #region Strings
+
+        /// <summary>
+        /// Gets the length of a null-terminated string at a given address.
+        /// </summary>
+        /// <param name="address">The address of the string</param>
+        /// <returns>The length of the string</returns>
+        /// <remarks>
+        /// This method counts the number of bytes, not the number of characters.
+        /// </remarks>
+        public static int StringLength(nint address)
+        {
+            var ptr = (byte*)address;
+            var length = 0;
+
+            while (*ptr != 0)
+            {
+                ptr++;
+                length++;
+            }
+
+            return length;
+        }
+
+        /// <summary>
+        /// Reads a null-terminated string from a given address.
+        /// </summary>
+        /// <param name="address">The address of the string</param>
+        /// <param name="encoding">The encoding to use, or UTF8 if no encoding is given</param>
+        /// <returns>The string read</returns>
+        public static string ReadString(nint address, Encoding? encoding = null)
+        {
+            var length = StringLength(address);
+            return (encoding ?? Encoding.UTF8).GetString((byte*)address, length);
+        }
+
+        #region Mirror Methods for long
+
+        /// <inheritdoc cref="StringLength(nint)"/>
+        public static int StringLength(long address) => StringLength((nint)address);
+
+        /// <inheritdoc cref="ReadString(nint,Encoding)"/>
+        public static string ReadString(long address, Encoding? encoding = null) => ReadString((nint)address, encoding);
+
+        #endregion
+
+        #region Mirror Methods for byte*
+
+        /// <inheritdoc cref="StringLength(nint)"/>
+        public static int StringLength(byte* address) => StringLength((nint)address);
+
+        /// <inheritdoc cref="ReadString(nint,Encoding)"/>
+        public static string ReadString(byte* address, Encoding? encoding = null) => ReadString((nint)address, encoding);
+
+        #endregion
 
         #endregion
 

--- a/SharpPluginLoader.Core/Memory/Windows/WinApi.cs
+++ b/SharpPluginLoader.Core/Memory/Windows/WinApi.cs
@@ -19,6 +19,16 @@ namespace SharpPluginLoader.Core.Memory.Windows
         [LibraryImport("kernel32.dll")]
         public static partial ulong VirtualQuery(nint lpAddress, out MemoryBasicInformation lpBuffer, ulong dwLength);
 
+        [LibraryImport("kernel32.dll", EntryPoint = "LoadLibraryW")]
+        public static partial nint LoadLibrary([MarshalAs(UnmanagedType.LPWStr)] string lpFileName);
+
+        [LibraryImport("kernel32.dll", EntryPoint = "FreeLibrary")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool FreeLibrary(nint hModule);
+
+        [LibraryImport("kernel32.dll", EntryPoint = "GetProcAddress")]
+        public static partial nint GetProcAddress(nint hModule, [MarshalAs(UnmanagedType.LPStr)] string lpProcName);
+
         public static bool IsManagedAssembly(string path)
         {
             using var stream = File.OpenRead(path);

--- a/SharpPluginLoader.InternalCallGenerator/InternalCallMethod.cs
+++ b/SharpPluginLoader.InternalCallGenerator/InternalCallMethod.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace SharpPluginLoader.InternalCallGenerator;
+
+public struct InternalCallMethod(IMethodSymbol method, bool isUnsafe)
+{
+    public IMethodSymbol Method = method;
+    public bool IsUnsafe = isUnsafe;
+
+    public readonly void Deconstruct(out IMethodSymbol outMethod, out bool outIsUnsafe)
+    {
+        outMethod = Method;
+        outIsUnsafe = IsUnsafe;
+    }
+}

--- a/SharpPluginLoader.InternalCallGenerator/InternalCallSourceGenerator.cs
+++ b/SharpPluginLoader.InternalCallGenerator/InternalCallSourceGenerator.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace SharpPluginLoader.InternalCallGenerator;
+
+[Generator]
+public class InternalCallSourceGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        context.RegisterPostInitializationOutput(ctx => ctx.AddSource(
+            "InternalCallAttribute.g.cs",
+            SourceText.From(SourceGenerationHelper.Attribute, Encoding.UTF8)
+        ));
+        
+        var internalCalls = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: static (s, _) => IsSyntaxTargetForGeneration(s),
+                transform: static (ctx, _) => GetSemanticTargetForGeneration(ctx)!)
+            .Where(static m => m is not null);
+
+        IncrementalValueProvider<(Compilation, ImmutableArray<MethodDeclarationSyntax>)> compilationAndInternalCalls
+            = context.CompilationProvider.Combine(internalCalls.Collect());
+
+        context.RegisterSourceOutput(compilationAndInternalCalls,
+            static (spc, source) => Execute(source.Item1, source.Item2, spc));
+    }
+
+    public static void Execute(Compilation compilation, ImmutableArray<MethodDeclarationSyntax> methods,
+        SourceProductionContext context)
+    {
+        if (methods.IsDefaultOrEmpty)
+            return;
+        
+        var distinctICalls = methods.Distinct();
+
+        var methodsToGenerate = GetMethodsToGenerate(compilation, distinctICalls, context.CancellationToken);
+
+        if (methodsToGenerate.Count == 0)
+            return;
+
+        var source = SourceGenerationHelper.GenerateSource(methodsToGenerate, context);
+        context.AddSource("InternalCalls.g.cs", SourceText.From(source, Encoding.UTF8));
+    }
+
+    public static List<InternalCallMethod> GetMethodsToGenerate(Compilation compilation,
+        IEnumerable<MethodDeclarationSyntax> methods, CancellationToken ct)
+    {
+        List<InternalCallMethod> methodsToGenerate = [];
+
+        var icallAttribute = compilation.GetTypeByMetadataName(SourceGenerationHelper.FullAttributeName);
+        if (icallAttribute is null)
+            return methodsToGenerate;
+
+        foreach (var method in methods)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var semanticModel = compilation.GetSemanticModel(method.SyntaxTree);
+            if (semanticModel.GetDeclaredSymbol(method) is not IMethodSymbol methodSymbol)
+                continue;
+
+            if (methodSymbol.IsGenericMethod || !methodSymbol.IsPartialDefinition) // Generic methods are not supported
+                continue;
+            
+            var attributeData = methodSymbol.GetAttributes().FirstOrDefault(
+                ad => SymbolEqualityComparer.Default.Equals(ad.AttributeClass, icallAttribute));
+            var isUnsafe = attributeData?.ConstructorArguments
+                .Any(tc => tc.Type?.ToDisplayString() == SourceGenerationHelper.FullOptionsEnumName 
+                           && tc.Value is not null 
+                           && (int)tc.Value == 1) ?? false;
+            methodsToGenerate.Add(new InternalCallMethod(methodSymbol, isUnsafe));
+        }
+
+        return methodsToGenerate;
+    }
+
+    public static bool IsSyntaxTargetForGeneration(SyntaxNode syntax)
+    {
+        return syntax is MethodDeclarationSyntax { AttributeLists.Count: > 0 };
+    }
+
+    public static MethodDeclarationSyntax? GetSemanticTargetForGeneration(GeneratorSyntaxContext context)
+    {
+        var method = (MethodDeclarationSyntax)context.Node;
+        
+        foreach (var attributeList in method.AttributeLists)
+        {
+            foreach (var attribute in attributeList.Attributes)
+            {
+                if (context.SemanticModel.GetSymbolInfo(attribute).Symbol is not IMethodSymbol attributeSymbol)
+                    continue;
+                
+                var attributeType = attributeSymbol.ContainingType;
+                var fullName = attributeType?.ToDisplayString() ?? string.Empty;
+
+                if (fullName == SourceGenerationHelper.FullAttributeName)
+                    return method;
+            }
+        }
+
+        return null;
+    }
+}

--- a/SharpPluginLoader.InternalCallGenerator/InternalCallSourceGenerator.cs
+++ b/SharpPluginLoader.InternalCallGenerator/InternalCallSourceGenerator.cs
@@ -73,7 +73,7 @@ public class InternalCallSourceGenerator : IIncrementalGenerator
                 ad => SymbolEqualityComparer.Default.Equals(ad.AttributeClass, icallAttribute));
             var isUnsafe = attributeData?.ConstructorArguments
                 .Any(tc => tc.Type?.ToDisplayString() == SourceGenerationHelper.FullOptionsEnumName 
-                           && tc.Value is not null 
+                           && tc.Value is not null
                            && (int)tc.Value == 1) ?? false;
             methodsToGenerate.Add(new InternalCallMethod(methodSymbol, isUnsafe));
         }

--- a/SharpPluginLoader.InternalCallGenerator/Properties/launchSettings.json
+++ b/SharpPluginLoader.InternalCallGenerator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Profile 1": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\Examples\\ExperimentalTesting\\ExperimentalTesting.csproj"
+    }
+  }
+}

--- a/SharpPluginLoader.InternalCallGenerator/README.md
+++ b/SharpPluginLoader.InternalCallGenerator/README.md
@@ -1,0 +1,5 @@
+# SharpPluginLoader.InternalCallGenerator
+
+This is a source generator that generates internal calls. It is used in conjunction with [SharpPluginLoader](https://github.com/Fexty12573/SharpPluginLoader).
+
+See details on internal calls [here](https://fexty12573.github.io/SharpPluginLoader/Development/NativeComponents/).

--- a/SharpPluginLoader.InternalCallGenerator/SharpPluginLoader.InternalCallGenerator.csproj
+++ b/SharpPluginLoader.InternalCallGenerator/SharpPluginLoader.InternalCallGenerator.csproj
@@ -4,11 +4,18 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>12.0</LangVersion>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-		<Title>InternalCall Generator</Title>
+		<Title>SharpPluginLoader InternalCall Generator</Title>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<Nullable>enable</Nullable>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<IsRoslynComponent>true</IsRoslynComponent>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Authors>Fexty,Ando</Authors>
+		<Company />
+		<Description>A source generator to generate InternalCalls for plugins</Description>
+		<PackageProjectUrl>https://fexty12573.github.io/SharpPluginLoader/</PackageProjectUrl>
+		<PackageReadmeFile>$(ProjectDir)README.md</PackageReadmeFile>
+		<RepositoryUrl>https://github.com/Fexty12573/SharpPluginLoader</RepositoryUrl>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -21,6 +28,10 @@
 
 	<ItemGroup>
 		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+		<None Include="F:\source\repos\mhw-cs-plugin-loader\SharpPluginLoader.InternalCallGenerator\README.md">
+		  <Pack>True</Pack>
+		  <PackagePath>\</PackagePath>
+		</None>
 	</ItemGroup>
 
 </Project>

--- a/SharpPluginLoader.InternalCallGenerator/SharpPluginLoader.InternalCallGenerator.csproj
+++ b/SharpPluginLoader.InternalCallGenerator/SharpPluginLoader.InternalCallGenerator.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>12.0</LangVersion>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<Title>InternalCall Generator</Title>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<Nullable>enable</Nullable>
+		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+		<IsRoslynComponent>true</IsRoslynComponent>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+	</ItemGroup>
+
+</Project>

--- a/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
+++ b/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
@@ -271,7 +271,7 @@ public static class SourceGenerationHelper
                                        if (icalls.TryGetValue("{method.Name}", out var {method.Name}Ptr))
                                            _{method.Name}Ptr = ({fieldType}){method.Name}Ptr;
                                        else
-                                           Log.Error("Could not find InternalCall for method {method.Name}");
+                                           Log.Warn("Could not find InternalCall for method {method.Name}");
                                        """);
             
             // Clear reused string builders and lists

--- a/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
+++ b/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
@@ -1,0 +1,365 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace SharpPluginLoader.InternalCallGenerator;
+
+using TransformedType = (string? typeName, TypeConversionKind conversion);
+
+public static class SourceGenerationHelper
+{
+    public const string GeneratorNamespace = "SharpPluginLoader.InternalCallGenerator";
+    public const string AttributeName = "InternalCallAttribute";
+    public const string OptionsEnumName = "InternalCallOptions";
+    public const string FullAttributeName = $"{GeneratorNamespace}.{AttributeName}";
+    public const string FullOptionsEnumName = $"{GeneratorNamespace}.{OptionsEnumName}";
+    public const string Attribute = $$"""
+                                    namespace {{GeneratorNamespace}};
+                                    
+                                    public enum InternalCallOptions
+                                    {
+                                        None = 0,
+                                        
+                                        // Suppresses the GC transition when calling the function pointer
+                                        Unsafe = 1
+                                    }
+
+                                    [System.AttributeUsage(System.AttributeTargets.Method)]
+                                    public class {{AttributeName}}(InternalCallOptions options = InternalCallOptions.None) : System.Attribute
+                                    {
+                                        public InternalCallOptions Options { get; } = options;
+                                    }
+                                    """;
+
+    public static string GenerateSource(List<InternalCallMethod> internalCalls, SourceProductionContext context)
+    {
+        if (internalCalls.Count == 0)
+            return "";
+
+        var sb = new StringBuilder();
+        var fieldTypeSb = new StringBuilder(); // Used to generate the fields
+        var methodSb = new StringBuilder(); // Used to generate the methods
+        var methodBodySb = new StringBuilder(); // Used to generate the method body, cleared after each method
+        var uploadMethodSb = new StringBuilder(); // Used to generate the upload method
+        List<string> methodInvokeParams = []; // Used to store variable names for the function pointer invocation
+        List<string> pinStatements = []; // Used to store variables that need to be pinned
+        List<string> gcHandles = []; // Used to store the gc handles
+
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Runtime.InteropServices;");
+        sb.AppendLine("using System.Runtime.CompilerServices;");
+        sb.AppendLine("using System.Collections.Generic;");
+        sb.AppendLine("using SharpPluginLoader.Core;");
+        sb.AppendLine("using SharpPluginLoader.Core.Memory;");
+        sb.Append($$"""
+                  
+                  namespace {{internalCalls[0].Method.ContainingNamespace.ToDisplayString()}};
+
+                  public static unsafe partial class InternalCalls
+                  {
+                  
+                  """);
+
+        // Generate start of upload method
+        uploadMethodSb.Append("""
+                              
+                              public static void UploadInternalCalls(System.Collections.Generic.Dictionary<string, nint> icalls)
+                              {
+                              
+                              """);
+
+        // Each internal call needs
+        // - A field of the form: private static delegate* unmanaged<T..., R> <MethodName>Ptr;
+        // - A method of the form: public static unsafe partial R <MethodName>(T...);
+
+        // The allowed parameter/return types are:
+        // - Primitive types
+        // - Pointer types
+        // - Array types where the element type is a primitive type or a pointer type
+        // - ref/out types
+        // - string
+        foreach (var (method, isUnsafe) in internalCalls)
+        {
+            var transformedReturnType = TransformReturn(method, context);
+            if (transformedReturnType.typeName is null)
+                continue;
+
+            // Start field generation
+            fieldTypeSb.Append(isUnsafe
+                ? "delegate* unmanaged[SuppressGCTransition]<"
+                : "delegate* unmanaged<");
+
+            var retModifier = "";
+            if (method.ReturnsByRef)
+                retModifier = "ref ";
+            else if (method.ReturnsByRefReadonly)
+                retModifier = "ref readonly ";
+            
+            // Start method generation
+            methodSb.Append($"public static partial {retModifier}{method.ReturnType.ToDisplayString()} {method.Name}(");
+
+            if (!method.ReturnsVoid)
+                methodBodySb.AppendLine($"{transformedReturnType.typeName} __result = default;");
+
+            for (var i = 0; i < method.Parameters.Length; ++i)
+            {
+                var param = method.Parameters[i];
+                var (typeName, conversion) = TransformParameter(param, context);
+
+                if (typeName is null)
+                    continue;
+                
+                var isLast = i == method.Parameters.Length - 1;
+
+                // Add the type to the field
+                fieldTypeSb.Append(typeName);
+                fieldTypeSb.Append(", "); // Comma always added as the return type is last
+
+                // Add the type to the method
+                methodSb.Append(param.ToDisplayString());
+                if (!isLast)
+                    methodSb.Append(", ");
+
+                string invokeParamName;
+                switch (conversion)
+                {
+                    case TypeConversionKind.Array:
+                        // Need to pin the array and get a pointer to the first element
+                        invokeParamName = $"t__{param.Name}";
+                        methodBodySb.AppendLine($"GCHandle gch_{param.Name} = GCHandle.Alloc({param.Name}, GCHandleType.Pinned);");
+                        methodBodySb.AppendLine(
+                            $"{typeName} {invokeParamName} = MemoryUtil.AsPointer(ref MemoryMarshal.GetArrayDataReference({param.Name}));");
+                        methodInvokeParams.Add(invokeParamName);
+                        gcHandles.Add($"gch_{param.Name}.Free();");
+                        break;
+                    case TypeConversionKind.RefOut:
+                        switch (param.RefKind)
+                        {
+                            case RefKind.Ref:
+                                invokeParamName = $"t__{param.Name}";
+                                pinStatements.Add($"fixed({typeName} {invokeParamName} = &{param.Name})");
+                                methodInvokeParams.Add(invokeParamName);
+                                break;
+                            case RefKind.Out:
+                                methodBodySb.AppendLine($"Unsafe.SkipInit(out {param.Name});");
+                                invokeParamName = $"t__{param.Name}";
+                                pinStatements.Add($"fixed({typeName} {invokeParamName} = &{param.Name})");
+                                methodInvokeParams.Add(invokeParamName);
+                                break;
+                            case RefKind.In:
+                                ReportError(context, "ICG003", "In parameters are not supported");
+                                methodInvokeParams.Add(param.Name);
+                                break;
+                            case RefKind.RefReadOnlyParameter:
+                                ReportError(context, "ICG004", "Ref readonly parameters are not supported");
+                                methodInvokeParams.Add(param.Name);
+                                break;
+                            case RefKind.None:
+                            default:
+                                throw new ArgumentOutOfRangeException();
+                        }
+                        break;
+                    case TypeConversionKind.String:
+                        throw new NotImplementedException();
+                    case TypeConversionKind.None:
+                    default:
+                        methodInvokeParams.Add(param.Name);
+                        break;
+                }
+            }
+
+            // Write the pin statements
+            foreach (var pinStatement in pinStatements)
+                methodBodySb.AppendLine(pinStatement);
+
+            // Invoke the function pointer
+            methodBodySb.AppendLine(transformedReturnType.typeName == "void"
+                ? $"_{method.Name}Ptr({string.Join(", ", methodInvokeParams)});"
+                : $"__result = _{method.Name}Ptr({string.Join(", ", methodInvokeParams)});");
+
+            foreach (var gch in gcHandles)
+                methodBodySb.AppendLine(gch);
+            
+            // Add the return statement
+            if (transformedReturnType.typeName != "void")
+            {
+                switch (transformedReturnType.conversion)
+                {
+                    case TypeConversionKind.None:
+                        methodBodySb.AppendLine("return __result;");
+                        break;
+                    case TypeConversionKind.Array:
+                        throw new InvalidOperationException("Array return types are not supported");
+                    case TypeConversionKind.RefOut:
+                        methodBodySb.AppendLine("return ref *__result;");
+                        break;
+                    case TypeConversionKind.String:
+                        throw new NotImplementedException();
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            // End field type generation
+            fieldTypeSb.Append($"{transformedReturnType.typeName}>");
+
+            // Generate field
+            sb.AppendLine($"private static {fieldTypeSb} _{method.Name}Ptr;");
+
+            // End method generation
+            methodSb.AppendLine(")");
+            methodSb.Append($$"""
+                             {
+                                 {{methodBodySb}}
+                             }
+                             """);
+
+            // Generate method
+            sb.AppendLine(methodSb.ToString());
+
+            // Add entry to upload method
+            var fieldType = fieldTypeSb.ToString();
+            uploadMethodSb.AppendLine($"_{method.Name}Ptr = ({fieldType})icalls[\"{method.Name}\"];");
+            
+            // Clear reused string builders and lists
+            methodBodySb.Clear();
+            methodInvokeParams.Clear();
+            pinStatements.Clear();
+            gcHandles.Clear();
+            fieldTypeSb.Clear();
+            methodSb.Clear();
+        }
+
+        // End upload method
+        uploadMethodSb.AppendLine("}");
+        
+        // Generate upload method
+        sb.AppendLine(uploadMethodSb.ToString());
+
+        // End class
+        sb.AppendLine("}");
+        
+        return sb.ToString();
+    }
+
+    private static TransformedType TransformParameter(IParameterSymbol param, SourceProductionContext context)
+    {
+        switch (param.Type)
+        {
+            case IArrayTypeSymbol arrayType:
+                if (param.RefKind != RefKind.None)
+                {
+                    ReportError(context, "ICG005", "Ref/out array parameters are not supported");
+                    return (null, TypeConversionKind.None);
+                }
+                return (TransformType(arrayType.ElementType, context).typeName + "*", TypeConversionKind.Array);
+            case IPointerTypeSymbol pointerType:
+                var (typeName, _) = TransformType(pointerType.PointedAtType, context);
+                return param.RefKind is RefKind.Ref or RefKind.Out 
+                    ? (typeName + "**", TypeConversionKind.RefOut) // ref/out pointers are represented as pointer to pointer
+                    : (typeName + "*", TypeConversionKind.None);
+            case INamedTypeSymbol namedType:
+                if (namedType.IsGenericType || !namedType.IsValueType)
+                {
+                    ReportError(context, "ICG001", "Generic types and reference types are not supported");
+                    return (null, TypeConversionKind.None);
+                }
+
+                var (type, _) = TransformType(namedType, context);
+                return param.RefKind is RefKind.Ref or RefKind.Out 
+                    ? (type + "*", TypeConversionKind.RefOut) // ref/out value types are represented as pointer to value type
+                    : (type, TypeConversionKind.None);
+            case ITypeParameterSymbol:
+                ReportError(context, "ICG002", "Type parameters are not supported");
+                return (null, TypeConversionKind.None);
+            default:
+                return (param.Type.ToDisplayString(), TypeConversionKind.None);
+        }
+    }
+
+    private static TransformedType TransformReturn(IMethodSymbol method, SourceProductionContext context)
+    {
+        if (method.ReturnsVoid)
+            return ("void", TypeConversionKind.None);
+
+        switch (method.ReturnType)
+        {
+            case IArrayTypeSymbol:
+                ReportError(context, "ICG006", "Array return types are not supported. Use a pointer instead.");
+                return (null, TypeConversionKind.None);
+            case IPointerTypeSymbol pointerType:
+                var (typeName, _) = TransformType(pointerType.PointedAtType, context);
+                return method.ReturnsByRef 
+                    ? (typeName + "**", TypeConversionKind.RefOut) 
+                    : (typeName + "*", TypeConversionKind.None);
+            case INamedTypeSymbol namedType:
+                if (namedType.IsGenericType || !namedType.IsValueType)
+                {
+                    ReportError(context, "ICG001", "Generic types and reference types are not supported");
+                    return (null, TypeConversionKind.None);
+                }
+                
+                var (type, _) = TransformType(namedType, context);
+                return method.ReturnsByRef 
+                    ? (type + "*", TypeConversionKind.RefOut) 
+                    : (type, TypeConversionKind.None);
+            case ITypeParameterSymbol:
+                ReportError(context, "ICG002", "Type parameters are not supported");
+                return (null, TypeConversionKind.None);
+            default:
+                return (method.ReturnType.ToDisplayString(), TypeConversionKind.None);
+        }
+    }
+
+    private static TransformedType TransformType(ITypeSymbol type, SourceProductionContext context)
+    {
+        switch (type)
+        {
+            case IArrayTypeSymbol arrayType:
+                return (TransformType(arrayType.ElementType, context).typeName + "*", TypeConversionKind.Array);
+            case IPointerTypeSymbol pointerType:
+                return (TransformType(pointerType.PointedAtType, context).typeName + "*", TypeConversionKind.None);
+            case INamedTypeSymbol namedType:
+                if (namedType.IsGenericType || !namedType.IsValueType)
+                {
+                    ReportError(context, "ICG001", "Generic types and reference types are not supported");
+                    return (null, TypeConversionKind.None);
+                }
+                
+                return namedType.IsRefLikeType
+                    ? ($"{namedType.ToDisplayString()}*", TypeConversionKind.RefOut)
+                    : (namedType.ToDisplayString(), TypeConversionKind.None);
+            case ITypeParameterSymbol:
+                ReportError(context, "ICG002", "Type parameters are not supported");
+                return (null, TypeConversionKind.None);
+            default:
+                return (type.ToDisplayString(), TypeConversionKind.None);
+        }
+    }
+
+    private static void ReportError(SourceProductionContext context, string id, string message)
+    {
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    id,
+                    "InternalCallGenerator",
+                    message,
+                    "InternalCallGenerator",
+                    DiagnosticSeverity.Error,
+                    true
+                ),
+                null
+            )
+        );
+    }
+}
+
+internal enum TypeConversionKind
+{
+    None = 0,
+    Array = 1,
+    RefOut = 2,
+    String = 3
+}

--- a/docs/Development/NativeComponents.md
+++ b/docs/Development/NativeComponents.md
@@ -1,0 +1,84 @@
+# Native Components
+Generally, most plugin-related things should be achievable in C# with the functionality provided by the framework. But sometimes it is perhaps easier to implement in C/C++ than in C#. Or maybe there is a C++ library that you want to use from your plugin.
+
+This is where Native Components come in. A native component is an unmanaged counterpart to a C# plugin. Usually when you need to interop with native code in C# you do so using [P/Invoke](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke). However the framework provides a more performant and versatile alternative to P/Invoke in the form of Internal Calls.
+
+Every plugin `PluginName.dll` can have a native component `PluginName.Native.dll`, which is required to be a native dll. Native components need to export 2 functions:
+```cpp
+#include "SPL/InternalCall.h"
+
+namespace SPLNative = SharpPluginLoader::Native;
+
+SPL_INTERNAL_CALL int get_internal_call_count() { 
+    // ... 
+}
+
+SPL_INTERNAL_CALL void collect_internal_calls(SPLNative::InternalCall* icalls) { 
+    // ...
+}
+```
+
+`get_internal_call_count` tells the framework how many internal calls are exported by the native component.
+
+In the `collect_internal_calls` function the native component then fills out the `icalls` array.
+
+For example, say you have some ImGui widget implemented in C++ that you want to expose to your plugin, your native component might look something like this:
+```cpp
+...
+bool my_imgui_widget(const char* label, int* values, unsigned flags) { ... }
+
+SPL_INTERNAL_CALL int get_internal_call_count() { return 1; }
+SPL_INTERNAL_CALL void collect_internal_calls(SPLNative::InternalCall* icalls) {
+    icalls[0] = { "MyImGuiWidget", &my_imgui_widget };
+}
+```
+
+The important part here is this line:
+```cpp
+icalls[0] = { "MyImGuiWidget", &my_imgui_widget };
+```
+
+The first component here is the name of the internal call on the C# side, which must match exactly. The second component is the function pointer.
+
+Now on the C# side you need to first add a reference to the `SharpPluginLoader.InternalCallGenerator` NuGet package to your plugin.
+
+Next you need to designate one class in your plugin as the internal call manager. Typically you would create a class dedicated to holding all of the internal calls. Technically however, you can make any class (even your main plugin class) the internal call manager. What is important though is that there can only be *one* internal call manager per plugin.
+
+```cs
+using SharpPluginLoader.InternalCallGenerator;
+
+[InternalCallManager]
+public partial class InternalCalls
+{
+    [InternalCall]
+    public static partial bool MyImGuiWidget(string label, Span<int> values, uint flags);
+}
+```
+
+The internal call manager is marked using the `[InternalCallManager]` attribute. Each internal call is then marked with an `[InternalCall]` attribute. It is required that the internal call manager class is `partial`. The same goes for all internal call methods, which must be marked `static partial`.
+
+This is all the code required on the managed side. Now you can call your native function by doing `InternalCalls.MyImGuiWidget("Test", [3, 4, 5]);`.
+
+Of course you can also bind an internal call to a game function directly:
+```cpp
+icalls[2] = { "SomeGameFunction", (void*)0x1430ae620 };
+```
+
+As you can see the managed function takes a `string` and a `Span<int>` as parameters. This works because the InternalCallGenerator will generate marshalling code for these types behind the scenes. Below is a list of managed types and what they map to on the native end:
+
+| Managed Type | Native Type | Copy Required | Remarks |
+| ------------ | ----------- | ------------- | ------- |
+| `string` | `char*` / `char8_t*` | Yes | UTF8 Encoding |
+| `[WideString] string` | `wchar_t*` / `char16_t*` | Yes | UTF16 Encoding |
+| `T[]` | `T*` | No | `T` must be unmanaged |
+| `T` | `T` | Yes | ^ |
+| `List<T>` | `T*` | No | ^ |
+| `{ReadOnly}Span<T>` | `T*` | No | ^ |
+| `{ReadOnly}Memory<T>` | `T*` | No | ^ |
+| `ref/out T` | `T*` | No | ^ |
+| `struct` | `struct` | Yes | The struct must be unmanaged (i.e. contain no reference types) |
+| `ref/out struct` | `struct*` | No | ^ |
+| `class` | Unsupported | | |
+
+## Other Languages
+It is also possible to write native components in languages other than C++ such as Rust. The only requirement is that the dll uses the [Microsoft x64 calling convention](https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170) for the two exported functions. This is the default calling convention when compiling C/C++ with MSVC on x64.

--- a/mhw-cs-plugin-loader.sln
+++ b/mhw-cs-plugin-loader.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PreloadTesting", "Examples\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpPluginLoader.InternalCallGenerator", "SharpPluginLoader.InternalCallGenerator\SharpPluginLoader.InternalCallGenerator.csproj", "{CBD13575-CA0C-4EB5-821D-847A6EE5581F}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExperimentalTesting.Native", "Examples\ExperimentalTesting.Native\ExperimentalTesting.Native.vcxproj", "{E3BA4F2C-E79F-486E-8051-0835D8057C7D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -339,6 +341,30 @@ Global
 		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.RelWithDebInfo|x86.ActiveCfg = Release|Any CPU
 		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.RelWithDebInfo|x86.Build.0 = Release|Any CPU
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Debug|Any CPU.Build.0 = Debug|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Debug|x64.ActiveCfg = Debug|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Debug|x64.Build.0 = Debug|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Debug|x86.ActiveCfg = Debug|Win32
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Debug|x86.Build.0 = Debug|Win32
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.MinSizeRel|Any CPU.ActiveCfg = Debug|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.MinSizeRel|Any CPU.Build.0 = Debug|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.MinSizeRel|x64.ActiveCfg = Debug|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.MinSizeRel|x64.Build.0 = Debug|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.MinSizeRel|x86.ActiveCfg = Debug|Win32
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.MinSizeRel|x86.Build.0 = Debug|Win32
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Release|Any CPU.ActiveCfg = Release|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Release|Any CPU.Build.0 = Release|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Release|x64.ActiveCfg = Release|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Release|x64.Build.0 = Release|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Release|x86.ActiveCfg = Release|Win32
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.Release|x86.Build.0 = Release|Win32
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.RelWithDebInfo|Any CPU.ActiveCfg = Release|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.RelWithDebInfo|Any CPU.Build.0 = Release|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.RelWithDebInfo|x64.ActiveCfg = Release|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.RelWithDebInfo|x64.Build.0 = Release|x64
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.RelWithDebInfo|x86.ActiveCfg = Release|Win32
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D}.RelWithDebInfo|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -356,6 +382,7 @@ Global
 		{444FF57A-C89D-403C-ABFB-2CC6BA1D9FCE} = {93226706-71AC-41BC-A457-21D3CAA8C751}
 		{C37E5763-6EBE-45CE-A903-DEF1AEA64FEA} = {93226706-71AC-41BC-A457-21D3CAA8C751}
 		{CBD13575-CA0C-4EB5-821D-847A6EE5581F} = {22614599-FA47-4E69-8DBB-A183F0A4AE25}
+		{E3BA4F2C-E79F-486E-8051-0835D8057C7D} = {93226706-71AC-41BC-A457-21D3CAA8C751}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {623F8CBC-2C3B-488D-B7BB-0140A8201BB7}

--- a/mhw-cs-plugin-loader.sln
+++ b/mhw-cs-plugin-loader.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomPackets", "Examples\C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PreloadTesting", "Examples\PreloadTesting\PreloadTesting.csproj", "{C37E5763-6EBE-45CE-A903-DEF1AEA64FEA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpPluginLoader.InternalCallGenerator", "SharpPluginLoader.InternalCallGenerator\SharpPluginLoader.InternalCallGenerator.csproj", "{CBD13575-CA0C-4EB5-821D-847A6EE5581F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -313,6 +315,30 @@ Global
 		{C37E5763-6EBE-45CE-A903-DEF1AEA64FEA}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 		{C37E5763-6EBE-45CE-A903-DEF1AEA64FEA}.RelWithDebInfo|x86.ActiveCfg = Release|Any CPU
 		{C37E5763-6EBE-45CE-A903-DEF1AEA64FEA}.RelWithDebInfo|x86.Build.0 = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Debug|x64.Build.0 = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Debug|x86.Build.0 = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.MinSizeRel|x86.ActiveCfg = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.MinSizeRel|x86.Build.0 = Debug|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Release|x64.ActiveCfg = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Release|x64.Build.0 = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Release|x86.ActiveCfg = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.Release|x86.Build.0 = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.RelWithDebInfo|x86.ActiveCfg = Release|Any CPU
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F}.RelWithDebInfo|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -329,6 +355,7 @@ Global
 		{5EA27F04-B731-4766-88A4-221E659D9570} = {93226706-71AC-41BC-A457-21D3CAA8C751}
 		{444FF57A-C89D-403C-ABFB-2CC6BA1D9FCE} = {93226706-71AC-41BC-A457-21D3CAA8C751}
 		{C37E5763-6EBE-45CE-A903-DEF1AEA64FEA} = {93226706-71AC-41BC-A457-21D3CAA8C751}
+		{CBD13575-CA0C-4EB5-821D-847A6EE5581F} = {22614599-FA47-4E69-8DBB-A183F0A4AE25}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {623F8CBC-2C3B-488D-B7BB-0140A8201BB7}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Calling Native Functions: Development/CallingNativeFuncs.md
     - Rendering with ImGui: Development/ImGui.md
     - Rendering: Development/Rendering.md
+    - Native Components: Development/NativeComponents.md
   - API Reference:
     - API/index.md
   - Examples:


### PR DESCRIPTION
## Current API (Still up for debate)

### Managed API
```cs
using SharpPluginLoader.Core;
using SharpPluginLoader.InternalCallGenerator;

[InternalCallManager]
public partial class InternalCalls2 // Name doesn't matter, but partial is required.
{
    [InternalCall]
    public static int Sum(int[] nums); // public static required.

    [InternalCall(InternalCallOptions
        .Unsafe)] // Will suppress the GC transition when invoked. Don't use on long methods.
    public static bool ProcessData(byte[] data, out int result);

    // Non-internal call methods are allowed
    public static int ProcessDatasAndSum(byte[][] datas)
    {
        List<int> results = [];
        foreach (var data in datas)
        {
            if (ProcessData(data, out var result))
            {
                results.Add(result);
            }
        }

        return Sum([..results]);
    }
}
```

### Native API
```cpp
extern "C" int Sum(int* nums) { ... }

extern "C" bool ProcessData(u8* data, int* result) { ... }
```

The function name needs to match exactly on the managed and native ends.

