### PR TITLE
Refactor native loader config

### DIFF
--- a/mhw-cs-plugin-loader/.clang-tidy
+++ b/mhw-cs-plugin-loader/.clang-tidy
@@ -1,0 +1,9 @@
+Checks: '-*,readability-identifier-naming'
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.PrivateMemberPrefix, value: m_         }
+  - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,        value: lower_case }
+  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
+  - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }

--- a/mhw-cs-plugin-loader/.clang-tidy
+++ b/mhw-cs-plugin-loader/.clang-tidy
@@ -2,8 +2,9 @@ Checks: '-*,readability-identifier-naming'
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
   - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
-  - { key: readability-identifier-naming.PrivateMemberPrefix, value: m_         }
   - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
+  - { key: readability-identifier-naming.PrivateMemberPrefix, value: m_         }
+  - { key: readability-identifier-naming.PublicMemberCase,    value: CamelCase  }
   - { key: readability-identifier-naming.FunctionCase,        value: lower_case }
   - { key: readability-identifier-naming.VariableCase,        value: lower_case }
   - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }

--- a/mhw-cs-plugin-loader/Config.h
+++ b/mhw-cs-plugin-loader/Config.h
@@ -44,6 +44,8 @@ constexpr inline auto SPL_LOG_FILE_NAME = L"SharpPluginLoader.log"sv;
 // The path to the log file
 constexpr inline auto SPL_LOG_FILE = detail::concat<SPL_LOADER_DIR, SPL_LOG_FILE_NAME>;
 
+// The path of the loader config file
+constexpr inline auto SPL_LOADER_CONFIG_FILE = L"loader-config.json";
 
 // The name of the loader config file
 constexpr inline auto SPL_RUNTIME_CONFIG_FILE_NAME = L"SharpPluginLoader.runtimeconfig.json"sv;

--- a/mhw-cs-plugin-loader/Config.h
+++ b/mhw-cs-plugin-loader/Config.h
@@ -81,8 +81,4 @@ constexpr inline auto SPL_CORE_ASSEMBLY_NAME = L"SharpPluginLoader.Core"sv;
 // The path to the loader core assembly
 constexpr inline auto SPL_CORE_ASSEMBLY = detail::concat<SPL_LOADER_DIR, SPL_CORE_ASSEMBLY_FILE_NAME>;
 
-
-namespace detail {
-
-}
 }

--- a/mhw-cs-plugin-loader/LoaderConfig.cpp
+++ b/mhw-cs-plugin-loader/LoaderConfig.cpp
@@ -28,7 +28,7 @@ namespace preloader
         j.at("enablePluginLoader").get_to(c.enable_plugin_loader);
     }
 
-    LoaderConfig& LoaderConfig::Instance()
+    LoaderConfig& LoaderConfig::get()
     {
         static LoaderConfig instance;
         return instance;

--- a/mhw-cs-plugin-loader/LoaderConfig.cpp
+++ b/mhw-cs-plugin-loader/LoaderConfig.cpp
@@ -3,12 +3,11 @@
 #include <filesystem>
 #include <fstream>
 
+#include "Config.h"
 
 namespace preloader
 {
     using json = nlohmann::json;
-
-    const std::string config_name("loader-config.json");
 
     void to_json(json& j, const ConfigFile& c) {
         j = json{
@@ -37,9 +36,9 @@ namespace preloader
     LoaderConfig::LoaderConfig()
     {
         // Attempt to load file from disk
-        if (std::filesystem::exists(config_name))
+        if (std::filesystem::exists(config::SPL_LOADER_CONFIG_FILE))
         {
-            std::ifstream file(config_name);
+            std::ifstream file(config::SPL_LOADER_CONFIG_FILE);
             json data = json::parse(file);
             this->config = data.get<ConfigFile>();
             file.close();
@@ -56,7 +55,7 @@ namespace preloader
                 .enable_plugin_loader = true,
             };
 
-            std::ofstream file(config_name);
+            std::ofstream file(config::SPL_LOADER_CONFIG_FILE);
             if (file.is_open())
             {
                 json data = this->config;

--- a/mhw-cs-plugin-loader/LoaderConfig.cpp
+++ b/mhw-cs-plugin-loader/LoaderConfig.cpp
@@ -11,20 +11,20 @@ namespace preloader
 
     void to_json(json& j, const ConfigFile& c) {
         j = json{
-            {"logfile", c.log_file},
-            {"logcmd", c.log_cmd},
-            {"logLevel", c.log_level},
-            {"outputEveryPath", c.output_every_path},
-            {"enablePluginLoader", c.enable_plugin_loader}
+            {"logfile", c.LogFile},
+            {"logcmd", c.LogCmd},
+            {"logLevel", c.LogLevel},
+            {"outputEveryPath", c.OutputEveryPath},
+            {"enablePluginLoader", c.EnablePluginLoader}
         };
     }
 
     void from_json(const json& j, ConfigFile& c) {
-        j.at("logfile").get_to(c.log_file);
-        j.at("logcmd").get_to(c.log_cmd);
-        j.at("logLevel").get_to(c.log_level);
-        j.at("outputEveryPath").get_to(c.output_every_path);
-        j.at("enablePluginLoader").get_to(c.enable_plugin_loader);
+        j.at("logfile").get_to(c.LogFile);
+        j.at("logcmd").get_to(c.LogCmd);
+        j.at("logLevel").get_to(c.LogLevel);
+        j.at("outputEveryPath").get_to(c.OutputEveryPath);
+        j.at("enablePluginLoader").get_to(c.EnablePluginLoader);
     }
 
     LoaderConfig& LoaderConfig::get()
@@ -48,11 +48,11 @@ namespace preloader
             // No existing config, create a default and save to disk.
             this->config = ConfigFile
             {
-                .log_file = true,
-                .log_cmd = true,
-                .log_level = "INFO",
-                .output_every_path = false,
-                .enable_plugin_loader = true,
+                .LogFile = true,
+                .LogCmd = true,
+                .LogLevel = "INFO",
+                .OutputEveryPath = false,
+                .EnablePluginLoader = true,
             };
 
             std::ofstream file(config::SPL_LOADER_CONFIG_FILE);

--- a/mhw-cs-plugin-loader/LoaderConfig.cpp
+++ b/mhw-cs-plugin-loader/LoaderConfig.cpp
@@ -1,0 +1,68 @@
+#include "LoaderConfig.h"
+#include <string>
+#include <filesystem>
+#include <fstream>
+
+
+namespace preloader
+{
+    using json = nlohmann::json;
+
+    const std::string config_name("loader-config.json");
+
+    void to_json(json& j, const ConfigFile& c) {
+        j = json{
+            {"logfile", c.log_file},
+            {"logcmd", c.log_cmd},
+            {"logLevel", c.log_level},
+            {"outputEveryPath", c.output_every_path},
+            {"enablePluginLoader", c.enable_plugin_loader}
+        };
+    }
+
+    void from_json(const json& j, ConfigFile& c) {
+        j.at("logfile").get_to(c.log_file);
+        j.at("logcmd").get_to(c.log_cmd);
+        j.at("logLevel").get_to(c.log_level);
+        j.at("outputEveryPath").get_to(c.output_every_path);
+        j.at("enablePluginLoader").get_to(c.enable_plugin_loader);
+    }
+
+    LoaderConfig& LoaderConfig::Instance()
+    {
+        static LoaderConfig instance;
+        return instance;
+    }
+
+    LoaderConfig::LoaderConfig()
+    {
+        // Attempt to load file from disk
+        if (std::filesystem::exists(config_name))
+        {
+            std::ifstream file(config_name);
+            json data = json::parse(file);
+            this->config = data.get<ConfigFile>();
+            file.close();
+        }
+        else
+        {
+            // No existing config, create a default and save to disk.
+            this->config = ConfigFile
+            {
+                .log_file = true,
+                .log_cmd = true,
+                .log_level = "INFO",
+                .output_every_path = false,
+                .enable_plugin_loader = true,
+            };
+
+            std::ofstream file(config_name);
+            if (file.is_open())
+            {
+                json data = this->config;
+                file << std::setw(4) << data << "\n";
+                file.close();
+            }
+        }
+    }
+} // namespace preloader

--- a/mhw-cs-plugin-loader/LoaderConfig.h
+++ b/mhw-cs-plugin-loader/LoaderConfig.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <nlohmann/json.hpp>
+
+namespace preloader
+{
+    struct ConfigFile {
+        bool log_file;
+        bool log_cmd;
+        std::string log_level;
+        bool output_every_path;
+        bool enable_plugin_loader;
+    };
+    void to_json(nlohmann::json& j, const ConfigFile& c);
+    void from_json(const nlohmann::json& j, ConfigFile& c);
+
+
+    class LoaderConfig {
+    private:
+        LoaderConfig();
+        ~LoaderConfig() = default;
+
+        ConfigFile config;
+    public:
+        LoaderConfig(const LoaderConfig&) = delete;
+        LoaderConfig& operator = (const LoaderConfig&) = delete;
+
+        static LoaderConfig& Instance();
+
+        inline bool GetLogFile() const { return this->config.log_file; }
+        inline bool GetLogCmd() const { return this->config.log_cmd; }
+        inline std::string GetLogLevel() const { return this->config.log_level; }
+        inline bool GetOutputEveryPath() const { return this->config.output_every_path; }
+        inline bool GetEnablePluginLoader() const { return this->config.enable_plugin_loader; }
+    };
+} // namespace preloader

--- a/mhw-cs-plugin-loader/LoaderConfig.h
+++ b/mhw-cs-plugin-loader/LoaderConfig.h
@@ -4,11 +4,11 @@
 namespace preloader
 {
     struct ConfigFile {
-        bool log_file;
-        bool log_cmd;
-        std::string log_level;
-        bool output_every_path;
-        bool enable_plugin_loader;
+        bool LogFile;
+        bool LogCmd;
+        std::string LogLevel;
+        bool OutputEveryPath;
+        bool EnablePluginLoader;
     };
     void to_json(nlohmann::json& j, const ConfigFile& c);
     void from_json(const nlohmann::json& j, ConfigFile& c);
@@ -26,10 +26,10 @@ namespace preloader
 
         static LoaderConfig& get();
 
-        inline bool get_log_file() const { return this->config.log_file; }
-        inline bool get_log_cmd() const { return this->config.log_cmd; }
-        inline std::string get_log_level() const { return this->config.log_level; }
-        inline bool get_output_every_path() const { return this->config.output_every_path; }
-        inline bool get_enable_plugin_loader() const { return this->config.enable_plugin_loader; }
+        inline bool get_log_file() const { return this->config.LogFile; }
+        inline bool get_log_cmd() const { return this->config.LogCmd; }
+        inline std::string get_log_level() const { return this->config.LogLevel; }
+        inline bool get_output_every_path() const { return this->config.OutputEveryPath; }
+        inline bool get_enable_plugin_loader() const { return this->config.EnablePluginLoader; }
     };
 } // namespace preloader

--- a/mhw-cs-plugin-loader/LoaderConfig.h
+++ b/mhw-cs-plugin-loader/LoaderConfig.h
@@ -24,12 +24,12 @@ namespace preloader
         LoaderConfig(const LoaderConfig&) = delete;
         LoaderConfig& operator = (const LoaderConfig&) = delete;
 
-        static LoaderConfig& Instance();
+        static LoaderConfig& get();
 
-        inline bool GetLogFile() const { return this->config.log_file; }
-        inline bool GetLogCmd() const { return this->config.log_cmd; }
-        inline std::string GetLogLevel() const { return this->config.log_level; }
-        inline bool GetOutputEveryPath() const { return this->config.output_every_path; }
-        inline bool GetEnablePluginLoader() const { return this->config.enable_plugin_loader; }
+        inline bool get_log_file() const { return this->config.log_file; }
+        inline bool get_log_cmd() const { return this->config.log_cmd; }
+        inline std::string get_log_level() const { return this->config.log_level; }
+        inline bool get_output_every_path() const { return this->config.output_every_path; }
+        inline bool get_enable_plugin_loader() const { return this->config.enable_plugin_loader; }
     };
 } // namespace preloader

--- a/mhw-cs-plugin-loader/Log.cpp
+++ b/mhw-cs-plugin-loader/Log.cpp
@@ -28,10 +28,10 @@ static loader::LogLevel to_loader_level(LogLevel level) {
 
 static void log_raw(LogLevel level, const void* msg, size_t msg_length, const void* time_msg, size_t time_msg_length, OutputFunc write) {
     if (!s_console) {
-        auto& loaderConfig = preloader::LoaderConfig::Instance();
+        auto& loader_config = preloader::LoaderConfig::get();
 
-        const auto log_level = loaderConfig.GetLogLevel();
-        s_log_to_cmd = loaderConfig.GetLogCmd();
+        const auto log_level = loader_config.get_log_level();
+        s_log_to_cmd = loader_config.get_log_cmd();
 
         if (log_level == "DEBUG") {
             s_console_log_level = loader::DEBUG;

--- a/mhw-cs-plugin-loader/Log.cpp
+++ b/mhw-cs-plugin-loader/Log.cpp
@@ -1,5 +1,6 @@
 #include "Log.h"
 #include "Config.h"
+#include "LoaderConfig.h"
 
 #include <chrono>
 #include <fstream>
@@ -27,11 +28,10 @@ static loader::LogLevel to_loader_level(LogLevel level) {
 
 static void log_raw(LogLevel level, const void* msg, size_t msg_length, const void* time_msg, size_t time_msg_length, OutputFunc write) {
     if (!s_console) {
-        nlohmann::json config;
-        std::ifstream("loader-config.json") >> config;
+        auto& loaderConfig = preloader::LoaderConfig::Instance();
 
-        const auto log_level = config.value("logLevel", "INFO");
-        s_log_to_cmd = config.value("logcmd", true);
+        const auto log_level = loaderConfig.GetLogLevel();
+        s_log_to_cmd = loaderConfig.GetLogCmd();
 
         if (log_level == "DEBUG") {
             s_console_log_level = loader::DEBUG;

--- a/mhw-cs-plugin-loader/NativePluginFramework.cpp
+++ b/mhw-cs-plugin-loader/NativePluginFramework.cpp
@@ -25,14 +25,14 @@ NativePluginFramework::NativePluginFramework(CoreClr* coreclr)
     coreclr->initialize_core_assembly();
 }
 
-void NativePluginFramework::TriggerOnPreMain() {
+void NativePluginFramework::trigger_on_pre_main() {
     m_managed_functions.TriggerOnPreMain();
 }
 
-void NativePluginFramework::TriggerOnWinMain() {
+void NativePluginFramework::trigger_on_win_main() {
     m_managed_functions.TriggerOnWinMain();
 }
 
-void NativePluginFramework::TriggerOnMhMainCtor() {
+void NativePluginFramework::trigger_on_mh_main_ctor() {
     m_managed_functions.TriggerOnMhMainCtor();
 }

--- a/mhw-cs-plugin-loader/NativePluginFramework.h
+++ b/mhw-cs-plugin-loader/NativePluginFramework.h
@@ -28,9 +28,9 @@ public:
 
     explicit NativePluginFramework(CoreClr* coreclr);
 
-    void TriggerOnPreMain();
-    void TriggerOnWinMain();
-    void TriggerOnMhMainCtor();
+    void trigger_on_pre_main();
+    void trigger_on_win_main();
+    void trigger_on_mh_main_ctor();
 
 private:
     std::vector<std::shared_ptr<NativeModule>> m_modules;

--- a/mhw-cs-plugin-loader/Preloader.cpp
+++ b/mhw-cs-plugin-loader/Preloader.cpp
@@ -14,6 +14,7 @@
 #include "CoreClr.h"
 #include "Log.h"
 #include "Preloader.h"
+#include "LoaderConfig.h"
 #include "utility/game_functions.h"
 
 #pragma intrinsic(_ReturnAddress)
@@ -124,7 +125,11 @@ void hookedGetSystemTimeAsFileTime(LPFILETIME lpSystemTimeAsFileTime) {
 // binaries by detecting the first call to the hooked function _after_
 // the executable is unpacked in memory.
 void initialize_preloader() {
-    OpenConsole();
+    auto& loaderConfig = preloader::LoaderConfig::Instance();
+    if (loaderConfig.GetLogCmd())
+    {
+        OpenConsole();
+    }
 
     // Override the process security token that that the singleton instantiaion
     // happens, causing GetSystemTimeAsFileTime to be called pre-CRT init.

--- a/mhw-cs-plugin-loader/dllmain.cpp
+++ b/mhw-cs-plugin-loader/dllmain.cpp
@@ -5,12 +5,17 @@
 #include <windows.h>
 
 #include "Preloader.h"
+#include "LoaderConfig.h"
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     if (fdwReason == DLL_PROCESS_ATTACH) {
         // Only load the the mod loader DLL if winmm.dll has been loaded into the correct process.
         if (wil::GetModuleFileNameW<std::wstring>().contains(L"MonsterHunterWorld.exe")) {
-            initialize_preloader();
+            auto& loaderConfig = preloader::LoaderConfig::Instance();
+            if (loaderConfig.GetEnablePluginLoader())
+            {
+                initialize_preloader();
+            }
         }
     }
 

--- a/mhw-cs-plugin-loader/dllmain.cpp
+++ b/mhw-cs-plugin-loader/dllmain.cpp
@@ -11,8 +11,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     if (fdwReason == DLL_PROCESS_ATTACH) {
         // Only load the the mod loader DLL if winmm.dll has been loaded into the correct process.
         if (wil::GetModuleFileNameW<std::wstring>().contains(L"MonsterHunterWorld.exe")) {
-            auto& loaderConfig = preloader::LoaderConfig::Instance();
-            if (loaderConfig.GetEnablePluginLoader())
+            auto& loader_config = preloader::LoaderConfig::get();
+            if (loader_config.get_enable_plugin_loader())
             {
                 initialize_preloader();
             }

--- a/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj
+++ b/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj
@@ -163,6 +163,7 @@
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="GuiModule.cpp" />
     <ClCompile Include="ImGuiModule.cpp" />
+    <ClCompile Include="LoaderConfig.cpp" />
     <ClCompile Include="Log.cpp" />
     <ClCompile Include="NativeModule.cpp" />
     <ClCompile Include="NativePluginFramework.cpp" />
@@ -191,6 +192,7 @@
     <ClInclude Include="FileSystemItem.h" />
     <ClInclude Include="HResultHandler.h" />
     <ClInclude Include="ImGuiModule.h" />
+    <ClInclude Include="LoaderConfig.h" />
     <ClInclude Include="Log.h" />
     <ClInclude Include="NativeModule.h" />
     <ClInclude Include="NativePluginFramework.h" />

--- a/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj
+++ b/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj
@@ -70,6 +70,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <EnableClangTidyCodeAnalysis>true</EnableClangTidyCodeAnalysis>
+  </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <VcpkgUseStatic>true</VcpkgUseStatic>
     <VcpkgUseMD>true</VcpkgUseMD>
@@ -205,6 +208,7 @@
   <ItemGroup>
     <None Include="..\README.md" />
     <None Include="..\vcpkg.json" />
+    <None Include=".clang-tidy" />
     <None Include="SharpPluginLoader.runtimeconfig.json" />
   </ItemGroup>
   <ItemGroup>

--- a/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj.filters
+++ b/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj.filters
@@ -199,5 +199,6 @@
     <None Include="Shaders\PrimitiveRenderingVS.hlsl">
       <Filter>Resource Files\Shaders</Filter>
     </None>
+    <None Include=".clang-tidy" />
   </ItemGroup>
 </Project>

--- a/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj.filters
+++ b/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClCompile Include="Preloader.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="LoaderConfig.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CoreClr.h">
@@ -174,6 +177,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="LoaderConfig.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This MR extracts the `loader-config.json` parsing into a singleton class for easier use throughout the native code, while also keeping compatibility with the JSON format in Strackeror's loader. If the config file does not already exist when loading, we generate a default and write it to disk.

This also updates the preloader/native code to actually respect these options where it didn't previously (enable/disable and opening cmd window).