### PR TITLE
Improved Internal Calls

### DIFF
--- a/Examples/ExperimentalTesting/InternalCalls.cs
+++ b/Examples/ExperimentalTesting/InternalCalls.cs
@@ -82,32 +82,12 @@ public partial class InternalCalls
     [InternalCall]
     public static partial void ListTest(List<byte> list);
 
-    [InternalCall(Pattern = "AB CD EF 90")]
-    public static partial void PatternTest();
+    [InternalCall(Address = 0x142552c10)]
+    public static partial void D3DCheckResult(int result, string message);
 
-    [InternalCall(Pattern = "AB CD EF 90", Offset = -23)]
-    public static partial void PatternWithOffsetTest();
+    [InternalCall(Pattern = "48 89 5C 24 18 57 48 83 EC 20 8B D9 48 89 6C 24 30", Offset = -8)]
+    public static partial void D3DCheckResultPattern(int result, string message);
 
-    [InternalCall(Pattern = "AB CD EF 90", Cache = true)]
-    public static partial void PatternWithCacheTest();
-
-    [InternalCall(Pattern = "AB CD EF 90", Offset = -23, Cache = true)]
-    public static partial void PatternWithOffsetAndCacheTest();
-
-    [InternalCall(Address = 0x1234567890)]
-    public static partial void AddressTest();
-
-    [InternalCall(Address = 0x1234567890, Pattern = "AB CD EF 90")]
-    public static partial void AddressAndPatternTest();
-
-    [InternalCall(Address = 0x1234567890, Pattern = "AB CD EF 90", Offset = -23)]
-    public static partial void AddressPatternAndOffsetTest();
-
-    [InternalCall(InternalCallOptions.Unsafe, Address = 0x1234567890)]
-    public static partial void UnsafeAddressTest();
-
-    public static void X(IDictionary<string, nint> dict)
-    {
-        dict["test"] = 0x12345890;
-    }
+    [InternalCall(Pattern = "74 41 41 B9 00 08 00 00 48 C7 44 24 20 00 00 00 00", Offset = -15, Cache = true)]
+    public static partial void DisplayFatalErrorMessage(string message);
 }

--- a/Examples/ExperimentalTesting/InternalCalls.cs
+++ b/Examples/ExperimentalTesting/InternalCalls.cs
@@ -81,4 +81,28 @@ public partial class InternalCalls
 
     [InternalCall]
     public static partial void ListTest(List<byte> list);
+
+    [InternalCall(Pattern = "AB CD EF 90")]
+    public static partial void PatternTest();
+
+    [InternalCall(Pattern = "AB CD EF 90", Offset = -23)]
+    public static partial void PatternWithOffsetTest();
+
+    [InternalCall(Pattern = "AB CD EF 90", Cache = true)]
+    public static partial void PatternWithCacheTest();
+
+    [InternalCall(Pattern = "AB CD EF 90", Offset = -23, Cache = true)]
+    public static partial void PatternWithOffsetAndCacheTest();
+
+    [InternalCall(Address = 0x1234567890)]
+    public static partial void AddressTest();
+
+    [InternalCall(Address = 0x1234567890, Pattern = "AB CD EF 90")]
+    public static partial void AddressAndPatternTest();
+
+    [InternalCall(Address = 0x1234567890, Pattern = "AB CD EF 90", Offset = -23)]
+    public static partial void AddressPatternAndOffsetTest();
+
+    [InternalCall(InternalCallOptions.Unsafe, Address = 0x1234567890)]
+    public static partial void UnsafeAddressTest();
 }

--- a/Examples/ExperimentalTesting/Plugin.cs
+++ b/Examples/ExperimentalTesting/Plugin.cs
@@ -55,8 +55,13 @@ namespace ExperimentalTesting
         {
             ImGui.InputText("Message", ref _str, 512);
             ImGui.SameLine();
-            if (ImGui.Button("Log"))
-                InternalCalls.LogMessage(1, _str);
+            if (ImGui.Button("Display Fatal Error"))
+                InternalCalls.DisplayFatalErrorMessage(_str);
+
+            ImGui.InputInt("HRESULT", ref _value);
+            ImGui.SameLine();
+            if (ImGui.Button("Display Error"))
+                InternalCalls.D3DCheckResult(_value, "SPL: Test Error message");
 
             ImGui.Separator();
 

--- a/SharpPluginLoader.Bootstrapper/CoreLoadContext.cs
+++ b/SharpPluginLoader.Bootstrapper/CoreLoadContext.cs
@@ -18,7 +18,7 @@ namespace SharpPluginLoader.Bootstrapper
             _resolver = new AssemblyDependencyResolver(pluginPath);
         }
 
-        protected override Assembly Load(AssemblyName assemblyName)
+        protected override Assembly? Load(AssemblyName assemblyName)
         {
             EntryPoint.Log(EntryPoint.LogLevel.Debug, $"[Bootstrapper] Loading {assemblyName.Name}");
             var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
@@ -30,8 +30,15 @@ namespace SharpPluginLoader.Bootstrapper
             if (assembly != null)
                 return assembly;
 
-            assembly = Default.LoadFromAssemblyName(assemblyName);
-            return assembly;
+            try
+            {
+                assembly = Default.LoadFromAssemblyName(assemblyName);
+                return assembly;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
 
         /// <summary>
@@ -42,7 +49,7 @@ namespace SharpPluginLoader.Bootstrapper
         public Assembly LoadNoLock(AssemblyName assemblyName)
         {
             var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
-            if (assemblyPath == null) 
+            if (assemblyPath == null)
                 return Default.LoadFromAssemblyName(assemblyName);
 
             var bytes = File.ReadAllBytes(assemblyPath);

--- a/SharpPluginLoader.Core/InternalCalls.cs
+++ b/SharpPluginLoader.Core/InternalCalls.cs
@@ -35,6 +35,8 @@ namespace SharpPluginLoader.Core
         public static delegate* unmanaged<nint, nint, void> RenderObbPtr;
         public static delegate* unmanaged<nint, nint, void> RenderCapsulePtr;
         public static delegate* unmanaged<nint, nint, void> RenderLinePtr;
+
+        public static delegate* unmanaged<sbyte*> GetGameRevisionPtr;
 #pragma warning restore CS0649
 
         public static void TestInternalCall() => TestInternalCallPtr();
@@ -102,5 +104,11 @@ namespace SharpPluginLoader.Core
         public static void RenderCapsule(nint capsulePtr, nint colorPtr) => RenderCapsulePtr(capsulePtr, colorPtr);
 
         public static void RenderLine(nint linePtr, nint colorPtr) => RenderLinePtr(linePtr, colorPtr);
+
+        public static string GetGameRevision()
+        {
+            var revision = GetGameRevisionPtr();
+            return revision == null ? string.Empty : new string(revision);
+        }
     }
 }

--- a/SharpPluginLoader.Core/Memory/AddressRepository.cs
+++ b/SharpPluginLoader.Core/Memory/AddressRepository.cs
@@ -85,10 +85,10 @@ namespace SharpPluginLoader.Core.Memory
 
         private static void LoadPluginRecords()
         {
-            using var fs = File.Exists(PluginCachePath) 
-                ? File.OpenRead(PluginCachePath) 
-                : File.Create(PluginCachePath);
+            if (!File.Exists(PluginCachePath))
+                return;
 
+            using var fs = File.OpenRead(PluginCachePath);
             var pluginCache = JsonSerializer.Deserialize<PluginRecordCacheJson>(fs, SerializerOptions)
                 ?? throw new Exception("Failed to deserialize plugin records cache");
 

--- a/SharpPluginLoader.Core/Memory/AddressRepository.cs
+++ b/SharpPluginLoader.Core/Memory/AddressRepository.cs
@@ -24,8 +24,10 @@ namespace SharpPluginLoader.Core.Memory
             var addressRecords = JsonSerializer.Deserialize<AddressRecordJson[]>(addressRecordsString, SerializerOptions)
               ?? throw new Exception("Failed to deserialize address records");
 
+            var gameVersion = InternalCalls.GetGameRevision();
+            if (string.IsNullOrEmpty(gameVersion))
+                throw new Exception("Failed to get game revision");
 
-            var gameVersion = GetGameRevision(addressRecords);
             Log.Debug($"[Core] Attempting to initialize address repository for game revision: {gameVersion}");
             var addressRecordFileHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(addressRecordsString)));
 

--- a/SharpPluginLoader.Core/Memory/AddressRepository.cs
+++ b/SharpPluginLoader.Core/Memory/AddressRepository.cs
@@ -134,32 +134,6 @@ namespace SharpPluginLoader.Core.Memory
             File.WriteAllText(PluginCachePath, cacheJson);
         }
 
-        private static unsafe string GetGameRevision(AddressRecordJson[] records)
-        {
-            // TODO: It's weird to scan for this here.
-            // If we get an update, we _probably_ won't be able to get to this point
-            // due to hardcoded addresses in the native core.
-            // This should AOB scanned in native and exposed as an icall.
-
-            var gameBuildRevisionJsonRecord = records.FirstOrDefault(r => r.Name == "Core::GetGameBuildRevision")
-                ?? throw new Exception("Failed to get Core::GetGameBuildRevision from address records");
-
-            var addressRecord = new AddressRecord(gameBuildRevisionJsonRecord.Pattern, gameBuildRevisionJsonRecord.Offset)
-                ?? throw new Exception("Failed scan for Core::GetGameBuildRevision");
-
-
-            // We unfortunately can't call this function directly, as it uses CRT functions
-            // that might not have been initialized yet. Instead, we just parse the offset
-            // in the instruction to the constant.
-            // var getGameBuildRevision = new NativeFunction<nint>(addressRecord.Address);
-            var constantOffset = Memory.MemoryUtil.Read<UInt32>(addressRecord.Address+7);
-            var constantBase = addressRecord.Address + 11;
-            var gameVersionPtr = MemoryUtil.Read<nint>(constantBase + constantOffset);
-            var gameVersion = MemoryUtil.ReadString(gameVersionPtr);
-
-            return gameVersion;
-        }
-
         public static nint Get(string name)
         {
            if (Records.TryGetValue(name, out var record)) 

--- a/SharpPluginLoader.Core/Memory/PluginRecordCacheJson.cs
+++ b/SharpPluginLoader.Core/Memory/PluginRecordCacheJson.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpPluginLoader.Core.Memory;
+
+internal class PluginRecordCacheJson
+{
+    public required string Version { get; set; }
+    public required Dictionary<string, ulong> Addresses { get; set; }
+}

--- a/SharpPluginLoader.Core/NativeInterface.cs
+++ b/SharpPluginLoader.Core/NativeInterface.cs
@@ -136,7 +136,7 @@ namespace SharpPluginLoader.Core
 
         public static void ReloadPlugin([MarshalAs(UnmanagedType.LPStr)] string pluginName)
         {
-            PluginManager.Instance.ReloadPlugin(pluginName);
+            PluginManager.Instance.ReloadPlugin(pluginName, true);
         }
 
         public static nint FindCoreMethod(string typeName, string methodName)

--- a/SharpPluginLoader.InternalCallGenerator/InternalCallMethod.cs
+++ b/SharpPluginLoader.InternalCallGenerator/InternalCallMethod.cs
@@ -2,12 +2,17 @@
 
 namespace SharpPluginLoader.InternalCallGenerator;
 
-public struct InternalCallMethod(IMethodSymbol method, bool isUnsafe)
+public readonly struct InternalCallMethod(IMethodSymbol method, bool isUnsafe, long address, 
+    string? pattern, int offset, bool cache)
 {
-    public IMethodSymbol Method = method;
-    public bool IsUnsafe = isUnsafe;
+    public IMethodSymbol Method { get; } = method;
+    public bool IsUnsafe { get; } = isUnsafe;
+    public long Address { get; } = address;
+    public string? Pattern { get; } = pattern;
+    public int Offset { get; } = offset;
+    public bool Cache { get; } = cache;
 
-    public readonly void Deconstruct(out IMethodSymbol outMethod, out bool outIsUnsafe)
+    public void Deconstruct(out IMethodSymbol outMethod, out bool outIsUnsafe)
     {
         outMethod = Method;
         outIsUnsafe = IsUnsafe;

--- a/SharpPluginLoader.InternalCallGenerator/InternalCallSourceGenerator.cs
+++ b/SharpPluginLoader.InternalCallGenerator/InternalCallSourceGenerator.cs
@@ -75,7 +75,38 @@ public class InternalCallSourceGenerator : IIncrementalGenerator
                 .Any(tc => tc.Type?.ToDisplayString() == SourceGenerationHelper.FullOptionsEnumName 
                            && tc.Value is not null
                            && (int)tc.Value == 1) ?? false;
-            methodsToGenerate.Add(new InternalCallMethod(methodSymbol, isUnsafe));
+
+            // Check for named arguments
+            long address = 0;
+            string? pattern = null;
+            var offset = 0;
+            var cache = false;
+
+            if (attributeData is not null)
+            {
+                foreach (var namedArg in attributeData.NamedArguments)
+                {
+                    switch (namedArg.Key)
+                    {
+                        case SourceGenerationHelper.AddressPropertyName:
+                            address = (long)namedArg.Value.Value!;
+                            break;
+                        case SourceGenerationHelper.PatternPropertyName:
+                            pattern = (string?)namedArg.Value.Value!;
+                            break;
+                        case SourceGenerationHelper.OffsetPropertyName:
+                            offset = (int)namedArg.Value.Value!;
+                            break;
+                        case SourceGenerationHelper.CachePropertyName:
+                            cache = (bool)namedArg.Value.Value!;
+                            break;
+                    }
+                }
+            }
+
+            methodsToGenerate.Add(
+                new InternalCallMethod(methodSymbol, isUnsafe, address, pattern, offset, cache)
+            );
         }
 
         return methodsToGenerate;

--- a/SharpPluginLoader.InternalCallGenerator/InternalCallSourceGenerator.cs
+++ b/SharpPluginLoader.InternalCallGenerator/InternalCallSourceGenerator.cs
@@ -80,7 +80,7 @@ public class InternalCallSourceGenerator : IIncrementalGenerator
             long address = 0;
             string? pattern = null;
             var offset = 0;
-            var cache = false;
+            var cache = true;
 
             if (attributeData is not null)
             {

--- a/SharpPluginLoader.InternalCallGenerator/SharpPluginLoader.InternalCallGenerator.csproj
+++ b/SharpPluginLoader.InternalCallGenerator/SharpPluginLoader.InternalCallGenerator.csproj
@@ -16,6 +16,9 @@
 		<PackageProjectUrl>https://fexty12573.github.io/SharpPluginLoader/</PackageProjectUrl>
 		<PackageReadmeFile>$(ProjectDir)README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/Fexty12573/SharpPluginLoader</RepositoryUrl>
+		<AssemblyVersion></AssemblyVersion>
+		<FileVersion>1.1.0</FileVersion>
+		<Version>1.1.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
+++ b/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
@@ -32,18 +32,24 @@ public static class SourceGenerationHelper
                                     }
 
                                     [System.AttributeUsage(System.AttributeTargets.Method)]
-                                    public class {{AttributeName}}) : System.Attribute
+                                    public class {{AttributeName}}(InternalCallOptions options = InternalCallOptions.None) : System.Attribute
                                     {
-                                        public InternalCallOptions Options;
-                                        public long Address;
-                                        public string? Pattern;
-                                        public int Offset;
-                                        public bool Cache;
+                                        public InternalCallOptions {{OptionsPropertyName}} = options;
+                                        public long {{AddressPropertyName}};
+                                        public string? {{PatternPropertyName}};
+                                        public int {{OffsetPropertyName}};
+                                        public bool {{CachePropertyName}} = true;
                                     }
                                     
                                     [System.AttributeUsage(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
                                     public class {{WideStringAttributeName}} : System.Attribute;
                                     """;
+
+    public const string OptionsPropertyName = "Options";
+    public const string AddressPropertyName = "Address";
+    public const string PatternPropertyName = "Pattern";
+    public const string OffsetPropertyName = "Offset";
+    public const string CachePropertyName = "Cache";
 
     private static IMethodSymbol? _currentMethodSymbol;
 

--- a/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
+++ b/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
@@ -88,8 +88,8 @@ public static class SourceGenerationHelper
         // Generate start of upload method
         uploadMethodSb.Append("""
                               
-                              public static void UploadInternalCalls(System.Collections.Generic.Dictionary<string, nint> icalls,
-                                    System.Collections.Generic.Dictionary<string, nint> addressCache)
+                              public static void UploadInternalCalls(System.Collections.Generic.IDictionary<string, nint> icalls,
+                                    System.Collections.Generic.IDictionary<string, nint> addressCache)
                               {
                               
                               """);

--- a/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
+++ b/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
@@ -305,22 +305,22 @@ public static class SourceGenerationHelper
                         }
                         else
                         {
-                            var {{method.Name}}_scanResults = PatternScanner.Scan(Pattern.FromString("{{icall.Pattern}}"));
-                            if ({{method.Name}}_scanResults.Count == 0)
+                            var {{method.Name}}_scanResult = PatternScanner.FindFirst(Pattern.FromString("{{icall.Pattern}}"));
+                            if ({{method.Name}}_scanResult == 0)
                                 Log.Warn("Could not find pattern for method {{method.Name}}");
                             else
                             {
-                                _{{method.Name}}Ptr = ({{fieldType}})({{method.Name}}_scanResults[0] + {{icall.Offset}});
+                                _{{method.Name}}Ptr = ({{fieldType}})({{method.Name}}_scanResult + {{icall.Offset}});
                                 addressCache["{{containingNamespace}}:{{method.Name}}"] = (nint)_{{method.Name}}Ptr;
                             }
                         }
                         """
                     : $"""
-                       var {method.Name}_scanResults = PatternScanner.Scan(Pattern.FromString("{icall.Pattern}"));
-                       if ({method.Name}_scanResults.Count == 0)
+                       var {method.Name}_scanResult = PatternScanner.FindFirst(Pattern.FromString("{icall.Pattern}"));
+                       if ({method.Name}_scanResult == 0)
                            Log.Warn("Could not find pattern for method {method.Name}");
                        else
-                           _{method.Name}Ptr = ({fieldType})({method.Name}_scanResults[0] + {icall.Offset});
+                           _{method.Name}Ptr = ({fieldType})({method.Name}_scanResult + {icall.Offset});
                        """);
             }
             else

--- a/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
+++ b/SharpPluginLoader.InternalCallGenerator/SourceGenerationHelper.cs
@@ -32,9 +32,13 @@ public static class SourceGenerationHelper
                                     }
 
                                     [System.AttributeUsage(System.AttributeTargets.Method)]
-                                    public class {{AttributeName}}(InternalCallOptions options = InternalCallOptions.None) : System.Attribute
+                                    public class {{AttributeName}}) : System.Attribute
                                     {
-                                        public InternalCallOptions Options { get; } = options;
+                                        public InternalCallOptions Options;
+                                        public long Address;
+                                        public string? Pattern;
+                                        public int Offset;
+                                        public bool Cache;
                                     }
                                     
                                     [System.AttributeUsage(System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]

--- a/mhw-cs-plugin-loader/NativePluginFramework.h
+++ b/mhw-cs-plugin-loader/NativePluginFramework.h
@@ -32,9 +32,12 @@ public:
     void trigger_on_win_main();
     void trigger_on_mh_main_ctor();
 
+    static const char* get_game_revision();
+
 private:
     std::vector<std::shared_ptr<NativeModule>> m_modules;
     ManagedFunctionPointers m_managed_functions;
+    const char* m_game_revision = nullptr;
 
     static inline NativePluginFramework* s_instance = nullptr;
 };

--- a/mhw-cs-plugin-loader/PatternScan.cpp
+++ b/mhw-cs-plugin-loader/PatternScan.cpp
@@ -5,7 +5,7 @@
 #include <Psapi.h>
 
 Pattern Pattern::from_string(const std::string& pattern) {
-    std::vector<i16> bytes;
+    std::vector<Byte> bytes;
     std::stringstream ss{ pattern };
     std::string byte;
 
@@ -17,10 +17,10 @@ Pattern Pattern::from_string(const std::string& pattern) {
         }
 
         if (byte == "?" || byte == "??") {
-            bytes.push_back(-1);
+            bytes.push_back({ true });
         }
         else {
-            bytes.push_back((i16)std::stoi(byte, nullptr, 16));
+            bytes.push_back({ .Value = (u8)std::stoul(byte, nullptr, 16) });
         }
     }
 
@@ -44,8 +44,8 @@ std::vector<uintptr_t> PatternScanner::scan(const Pattern& pattern) {
     const auto end_addr = addr + module_info.SizeOfImage;
     const auto& bytes = pattern.get_bytes();
 
-    const auto predicate = [](u8 byte, i16 pattern_byte) {
-        return pattern_byte == -1 || pattern_byte == byte;
+    const auto predicate = [](u8 byte, Pattern::Byte pattern_byte) {
+        return pattern_byte.IsWildcard || pattern_byte.Value == byte;
     };
 
     while (addr < end_addr) {
@@ -89,8 +89,8 @@ uintptr_t PatternScanner::find_first(const Pattern& pattern) {
     const auto end_addr = addr + module_info.SizeOfImage;
     const auto& bytes = pattern.get_bytes();
 
-    const auto predicate = [](u8 byte, i16 pattern_byte) {
-        return pattern_byte == -1 || pattern_byte == byte;
+    const auto predicate = [](u8 byte, Pattern::Byte pattern_byte) {
+        return pattern_byte.IsWildcard || pattern_byte.Value == byte;
     };
 
     while (addr < end_addr) {

--- a/mhw-cs-plugin-loader/PatternScan.cpp
+++ b/mhw-cs-plugin-loader/PatternScan.cpp
@@ -1,0 +1,117 @@
+#include "PatternScan.h"
+
+#include <algorithm>
+#include <Windows.h>
+#include <Psapi.h>
+
+Pattern Pattern::from_string(const std::string& pattern) {
+    std::vector<i16> bytes;
+    std::stringstream ss{ pattern };
+    std::string byte;
+
+    while (ss.good()) {
+        std::getline(ss, byte, ' ');
+
+        if (byte.empty()) {
+            continue;
+        }
+
+        if (byte == "?" || byte == "??") {
+            bytes.push_back(-1);
+        }
+        else {
+            bytes.push_back((i16)std::stoi(byte, nullptr, 16));
+        }
+    }
+
+    return Pattern(bytes);
+}
+
+std::vector<uintptr_t> PatternScanner::scan(const Pattern& pattern) {
+    std::vector<uintptr_t> results;
+
+    const auto module = GetModuleHandleA(nullptr); // MonsterHunterWorld.exe
+    if (!module) {
+        return results;
+    }
+
+    MODULEINFO module_info;
+    if (!GetModuleInformation(GetCurrentProcess(), module, &module_info, sizeof(module_info))) {
+        return results;
+    }
+
+    auto addr = (u8*)module;
+    const auto end_addr = addr + module_info.SizeOfImage;
+    const auto& bytes = pattern.get_bytes();
+
+    const auto predicate = [](u8 byte, i16 pattern_byte) {
+        return pattern_byte == -1 || pattern_byte == byte;
+    };
+
+    while (addr < end_addr) {
+        MEMORY_BASIC_INFORMATION mbi;
+        if (!VirtualQuery(addr, &mbi, sizeof(mbi)) || 
+            mbi.State != MEM_COMMIT ||
+            mbi.Protect & PAGE_GUARD) {
+            break;
+        }
+
+        const auto begin = (u8*)mbi.BaseAddress;
+        const auto end = begin + mbi.RegionSize;
+
+        auto found = std::search(begin, end, bytes.begin(), bytes.end(), predicate);
+
+        while (found != end) {
+            results.push_back((uintptr_t)found);
+            found = std::search(found + 1, end, bytes.begin(), bytes.end(), predicate);
+        }
+
+        addr = end;
+    }
+
+    return results;
+}
+
+uintptr_t PatternScanner::find_first(const Pattern& pattern) {
+    std::vector<uintptr_t> results;
+
+    const auto module = GetModuleHandleA(nullptr); // MonsterHunterWorld.exe
+    if (!module) {
+        return 0;
+    }
+
+    MODULEINFO module_info;
+    if (!GetModuleInformation(GetCurrentProcess(), module, &module_info, sizeof(module_info))) {
+        return 0;
+    }
+
+    auto addr = (u8*)module;
+    const auto end_addr = addr + module_info.SizeOfImage;
+    const auto& bytes = pattern.get_bytes();
+
+    const auto predicate = [](u8 byte, i16 pattern_byte) {
+        return pattern_byte == -1 || pattern_byte == byte;
+    };
+
+    while (addr < end_addr) {
+        MEMORY_BASIC_INFORMATION mbi;
+        if (!VirtualQuery(addr, &mbi, sizeof(mbi)) ||
+            mbi.State != MEM_COMMIT ||
+            mbi.Protect & PAGE_GUARD) {
+            break;
+        }
+
+        const auto begin = (u8*)mbi.BaseAddress;
+        const auto end = begin + mbi.RegionSize;
+
+        auto found = std::search(begin, end, bytes.begin(), bytes.end(), predicate);
+
+        if (found != end) {
+            return (uintptr_t)found;
+        }
+
+        addr = end;
+    }
+
+    return 0;
+}

--- a/mhw-cs-plugin-loader/PatternScan.h
+++ b/mhw-cs-plugin-loader/PatternScan.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "SharpPluginLoader.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+struct Pattern {
+    static Pattern from_string(const std::string& pattern);
+
+    const std::vector<i16>& get_bytes() const {
+        return m_bytes;
+    }
+
+    Pattern() = delete;
+
+private:
+    explicit Pattern(const std::vector<i16>& bytes) : m_bytes(bytes) {}
+
+    std::vector<i16> m_bytes;
+};
+
+class PatternScanner {
+public:
+    static std::vector<uintptr_t> scan(const Pattern& pattern);
+    static uintptr_t find_first(const Pattern& pattern);
+};
+
+

--- a/mhw-cs-plugin-loader/PatternScan.h
+++ b/mhw-cs-plugin-loader/PatternScan.h
@@ -7,18 +7,23 @@
 #include <vector>
 
 struct Pattern {
+    struct Byte {
+        bool IsWildcard = false;
+        u8 Value = 0;
+    };
+
     static Pattern from_string(const std::string& pattern);
 
-    const std::vector<i16>& get_bytes() const {
+    const std::vector<Byte>& get_bytes() const {
         return m_bytes;
     }
 
     Pattern() = delete;
 
 private:
-    explicit Pattern(const std::vector<i16>& bytes) : m_bytes(bytes) {}
+    explicit Pattern(const std::vector<Byte>& bytes) : m_bytes(bytes) {}
 
-    std::vector<i16> m_bytes;
+    std::vector<Byte> m_bytes;
 };
 
 class PatternScanner {

--- a/mhw-cs-plugin-loader/Preloader.cpp
+++ b/mhw-cs-plugin-loader/Preloader.cpp
@@ -2,7 +2,6 @@
 #include <string>
 #include <thread>
 
-#define WIN32_LEAN_AND_MEAN
 #include <wil/resource.h>
 #include <wil/stl.h>
 #include <wil/win32_helpers.h>

--- a/mhw-cs-plugin-loader/SharpPluginLoader.runtimeconfig.json
+++ b/mhw-cs-plugin-loader/SharpPluginLoader.runtimeconfig.json
@@ -1,9 +1,15 @@
 {
     "runtimeOptions": {
         "tfm": "net8.0",
-        "framework": {
-            "name": "Microsoft.NETCore.App",
-            "version": "8.0.0"
-        }
+        "frameworks": [
+            {
+                "name": "Microsoft.NETCore.App",
+                "version": "8.0.0"
+            },
+            {
+                "name": "Microsoft.WindowsDesktop.App",
+                "version": "8.0.0"
+            }
+        ]
     }
 }

--- a/mhw-cs-plugin-loader/dllmain.cpp
+++ b/mhw-cs-plugin-loader/dllmain.cpp
@@ -1,4 +1,3 @@
-#define WIN32_LEAN_AND_MEAN
 #include <wil/resource.h>
 #include <wil/stl.h>
 #include <wil/win32_helpers.h>

--- a/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj
+++ b/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="Log.cpp" />
     <ClCompile Include="NativeModule.cpp" />
     <ClCompile Include="NativePluginFramework.cpp" />
+    <ClCompile Include="PatternScan.cpp" />
     <ClCompile Include="Preloader.cpp" />
     <ClCompile Include="PrimitiveRenderingModule.cpp" />
     <ClCompile Include="Timeline.cpp" />
@@ -199,6 +200,7 @@
     <ClInclude Include="Log.h" />
     <ClInclude Include="NativeModule.h" />
     <ClInclude Include="NativePluginFramework.h" />
+    <ClInclude Include="PatternScan.h" />
     <ClInclude Include="Preloader.h" />
     <ClInclude Include="PrimitiveRenderingModule.h" />
     <ClInclude Include="Primitives.h" />

--- a/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj
+++ b/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj
@@ -117,7 +117,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);WIN32_LEAN_AND_MEAN</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(SolutionDir)dependencies\safetyhook\include;$(SolutionDir)dependencies\generic\include;$(SolutionDir)dependencies\imgui;$(SolutionDir)dependencies\cimgui\imgui;$(SolutionDir)dependencies\imgui-notify;$(SolutionDir)dependencies\loader\include</AdditionalIncludeDirectories>
@@ -137,7 +137,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);WIN32_LEAN_AND_MEAN</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(SolutionDir)dependencies\safetyhook\include;$(SolutionDir)dependencies\generic\include;$(SolutionDir)dependencies\imgui;$(SolutionDir)dependencies\cimgui\imgui;$(SolutionDir)dependencies\imgui-notify;$(SolutionDir)dependencies\loader\include</AdditionalIncludeDirectories>

--- a/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj.filters
+++ b/mhw-cs-plugin-loader/mhw-cs-plugin-loader.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClCompile Include="LoaderConfig.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="PatternScan.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CoreClr.h">
@@ -180,6 +183,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="LoaderConfig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="PatternScan.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Previously InternalCalls were limited in that they could only be bound to a function defined in a native dll. And while this could also be a game function this was still somewhat cumbersome.

This PR aims to alleviate that by adding new options to the `InternalCallAttribute`.

The currently planned API looks something this:
```cs
[InternalCall(Address = 0x141A5A3E0)]
public static partial MtObject CreateNewMonster(MtObject sEnemy, MonsterType type, uint variant, bool unk);

[InternalCall(Pattern = "33 C0 48 8D 4F 38 0F 1F 00", Offset = -119, Cache = true)]
public static partial MtObject CreateNewMonster2(MtObject sEnemy, MonsterType type, uint variant, bool unk);
```

This PR will also introduce automatic marshaling for any type that inherits from `SharpPluginLoader.Core.NativeWrapper`. The marshaling process is realized simply by passing the `Instance` member.