### PR TITLE
Update example plugins not using new interface

### DIFF
--- a/Examples/CustomPackets/Plugin.cs
+++ b/Examples/CustomPackets/Plugin.cs
@@ -7,19 +7,7 @@ namespace CustomPackets
     public class Plugin : IPlugin
     {
         public string Name => "CustomPackets";
-
-        public PluginData Initialize()
-        {
-            return new PluginData
-            {
-                OnUpdate = true,
-                OnReceivePacket = true
-            };
-        }
-
-        public void OnLoad()
-        {
-        }
+        public string Author => "Fexty";
 
         public void OnUpdate(float deltaTime)
         {

--- a/Examples/PreloadTesting/Plugin.cs
+++ b/Examples/PreloadTesting/Plugin.cs
@@ -9,6 +9,7 @@ namespace PreloadTesting
     public class Plugin : IPlugin
     {
         public string Name => "Preload Testing";
+        public string Author => "Ando";
 
         private delegate void StaticinitializerMtObjectDTI();
         private Hook<StaticinitializerMtObjectDTI> _staticinitializerMtObjectDTIHook = null!;
@@ -16,11 +17,7 @@ namespace PreloadTesting
         public PluginData Initialize()
         {
             Log.Debug("PreloadTesting->Initialize called!");
-            return new PluginData
-            {
-                OnPreMain = true,
-                OnWinMain = true
-            };
+            return new PluginData();
         }
 
         private unsafe void StaticinitializerMtObjectDTIHook()


### PR DESCRIPTION
Small fix for the `CustomPackets` and `PreloadTesting` example plugins that fail to compile when building the full solution.