### PR TITLE
Use proper fields for quest complete

### DIFF
--- a/SharpPluginLoader.Core/Quest.cs
+++ b/SharpPluginLoader.Core/Quest.cs
@@ -148,7 +148,7 @@ namespace SharpPluginLoader.Core
             _departOnQuestHook.Original(questMgr, unk);
         }
 
-        private static void EndQuestHook(nint questMgr, bool unk1, QuestEndReason reason, byte unk3)
+        private static void EndQuestHook(nint questMgr, bool unk1, nint frames, QuestEndReason reason)
         {
             switch (reason)
             {
@@ -169,7 +169,7 @@ namespace SharpPluginLoader.Core
                     break;
             }
 
-            _endQuestHook.Original(questMgr, unk1, reason, unk3);
+            _endQuestHook.Original(questMgr, unk1, frames, reason);
         }
 
         private static Hook<AcceptQuest> _acceptQuestHook = null!;
@@ -189,7 +189,7 @@ namespace SharpPluginLoader.Core
         private delegate void ReturnFromQuest(nint questMgr);
         private delegate void CancelQuest(nint questMgr);
         private delegate void DepartOnQuest(nint questMgr, bool unk);
-        private delegate void EndQuest(nint questMgr, bool unk1, QuestEndReason reason, byte unk3);
+        private delegate void EndQuest(nint questMgr, bool unk1, nint frames, QuestEndReason reason);
 
         private enum QuestEndReason : uint
         {


### PR DESCRIPTION
While troubleshooting some work around quest completion, I noticed I kept getting a message in my logs stating `Unknown quest end reason: 12389213` or similar numbers. After doing some investigation, the third parameter here is actually the number of frames that were used as part of the quest, and the final parameter is the reason parameter. 
Happy to walk through this if necessary, also only tested on Linux Proton, but I don't think that would matter for something like this.