### PR TITLE
Fix overlay not working after alt-tabbing / playing steamworks

### DIFF
--- a/mhw-cs-plugin-loader/D3DModule.cpp
+++ b/mhw-cs-plugin-loader/D3DModule.cpp
@@ -392,6 +392,7 @@ void D3DModule::initialize_for_d3d12_alt() {
         }
 
         if (!self->m_d3d12_command_queue) {
+            self->m_is_inside_present = false;
             return;
         }
 
@@ -403,6 +404,7 @@ void D3DModule::initialize_for_d3d12_alt() {
         // check if the app is even running, but whatever. This is (probably) a temporary fix.
         // +0x348 is the offset to cSteamControl, +0x444 is the offset from that to the mState field.
         if (facility && *(u32*)(facility + 0x348 + 0x444) > 5) {
+            self->m_is_inside_present = false;
             return;
         }
 
@@ -649,7 +651,6 @@ void D3DModule::d3d12_deinitialize_imgui() {
     m_d3d12_back_buffers = nullptr;
     m_d3d12_srv_heap = nullptr;
     m_d3d12_command_list = nullptr;
-    m_d3d12_command_queue = nullptr;
     m_d3d12_fence = nullptr;
     m_d3d12_fence_value = 0;
     m_d3d12_buffer_count = 0;


### PR DESCRIPTION
Tested on DirectX12 enabled + fullscreen.

When alt-tabbing, `d3d12_deinitialize_imgui` which is called by `d3d_resize_buffers_hook` gets called.
In `d3d12_deinitialize_imgui`, it nullifies `m_d3d12_command_queue` and it always be `nullptr` after that.
In Present hook, it checks if command queue is valid and also steamworks is not active.
If checks failed, it will return early but never assign back to `m_is_inside_present = false`.
This will cause an issue as title says.

This PR fixes the issue by just keeping command queue when deinitializing and assigning the flag back properly.

I know nothing about DirectX or rendering stuff, so sorry if this is not a proper fix.