### PR TITLE
Fix Path in MtFile

### DIFF
--- a/SharpPluginLoader.Core/IO/MtFile.cs
+++ b/SharpPluginLoader.Core/IO/MtFile.cs
@@ -21,7 +21,7 @@ public unsafe class MtFile : MtObject, IDisposable
     public static MtFile? Open(string path, OpenMode mode, bool createPath = true)
     {
         var dti = MtDti.Find("MtFile");
-        if (dti is null) 
+        if (dti is null)
             return null;
 
         var file = new MtFile(MemoryUtil.Alloc(dti.Size))
@@ -38,7 +38,7 @@ public unsafe class MtFile : MtObject, IDisposable
     /// <summary>
     /// Gets the path of the file.
     /// </summary>
-    public string Path => new(GetPtr<sbyte>(0x10));
+    public string Path => new(GetPtrInline<sbyte>(0x10));
 
     /// <summary>
     /// Gets the file pointer.


### PR DESCRIPTION
I ran into this using `MtFile.Open()` like this https://codeberg.org/pizzabelly/WorldTuningTool/src/commit/bf9d30011421064540bd34bab632ac3ed6450528/LUT.cs#L180.

A quick scan for other loaded `MtFile`'s shows that `Path` being inline is consistent.